### PR TITLE
feat: add routing and speed advice

### DIFF
--- a/lib/services/route_service.dart
+++ b/lib/services/route_service.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:latlong2/latlong.dart';
+
+class RouteService {
+  static Future<List<LatLng>> getRoute(LatLng start, LatLng end) async {
+    final url = Uri.parse(
+        'https://router.project-osrm.org/route/v1/driving/${start.longitude},${start.latitude};${end.longitude},${end.latitude}?overview=full&geometries=geojson');
+    final res = await http.get(url);
+    if (res.statusCode != 200) {
+      throw Exception('OSRM ${res.statusCode}');
+    }
+    final data = jsonDecode(res.body) as Map<String, dynamic>;
+    final routes = data['routes'] as List<dynamic>?;
+    if (routes == null || routes.isEmpty) {
+      throw Exception('No routes');
+    }
+    final coords =
+        (routes.first['geometry']['coordinates'] as List<dynamic>).cast<List<dynamic>>();
+    return coords
+        .map((c) => LatLng((c[1] as num).toDouble(), (c[0] as num).toDouble()))
+        .toList();
+  }
+}

--- a/lib/services/snap_utils.dart
+++ b/lib/services/snap_utils.dart
@@ -1,0 +1,61 @@
+import 'package:latlong2/latlong.dart';
+
+class SnappedLight {
+  final Map<String, dynamic> light;
+  final double distance;
+  SnappedLight({required this.light, required this.distance});
+}
+
+class SnapUtils {
+  static List<SnappedLight> snapLights(
+    List<Map<String, dynamic>> lights,
+    List<LatLng> route,
+    {double toleranceMeters = 40},
+  ) {
+    final dist = const Distance();
+    final res = <SnappedLight>[];
+    for (final l in lights) {
+      final lat = (l['lat'] as num?)?.toDouble();
+      final lon = (l['lon'] as num?)?.toDouble();
+      if (lat == null || lon == null) continue;
+      final p = LatLng(lat, lon);
+      double best = double.infinity;
+      double bestAlong = 0;
+      double traveled = 0;
+      for (int i = 0; i < route.length - 1; i++) {
+        final a = route[i];
+        final b = route[i + 1];
+        final segLen = dist(a, b);
+        final t = _projectT(p, a, b);
+        final proj = LatLng(
+            a.latitude + (b.latitude - a.latitude) * t,
+            a.longitude + (b.longitude - a.longitude) * t);
+        final d = dist(p, proj);
+        if (d < best) {
+          best = d;
+          bestAlong = traveled + segLen * t;
+        }
+        traveled += segLen;
+      }
+      if (best <= toleranceMeters) {
+        res.add(SnappedLight(light: l, distance: bestAlong));
+      }
+    }
+    res.sort((a, b) => a.distance.compareTo(b.distance));
+    return res;
+  }
+
+  static double _projectT(LatLng p, LatLng a, LatLng b) {
+    final ax = a.latitude;
+    final ay = a.longitude;
+    final bx = b.latitude;
+    final by = b.longitude;
+    final px = p.latitude;
+    final py = p.longitude;
+    final dx = bx - ax;
+    final dy = by - ay;
+    if (dx == 0 && dy == 0) return 0;
+    final t = ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy);
+    return t.clamp(0.0, 1.0);
+  }
+}

--- a/lib/services/speed_advisor.dart
+++ b/lib/services/speed_advisor.dart
@@ -1,0 +1,44 @@
+import 'snap_utils.dart';
+
+class SpeedAdvisor {
+  static int? advise(List<SnappedLight> lights) {
+    if (lights.isEmpty) return null;
+    final now = DateTime.now().toUtc();
+    int? best;
+    int bestScore = -9999;
+    for (int sp = 25; sp <= 70; sp += 5) {
+      final v = sp / 3.6; // m/s
+      int score = 0;
+      for (int i = 0; i < lights.length && i < 3; i++) {
+        final l = lights[i].light;
+        final dist = lights[i].distance;
+        final arrive = now.add(Duration(seconds: (dist / v).round()));
+        final ph = _phaseAt(l, arrive);
+        if (ph == _Phase.green) score += 2;
+        else if (ph == _Phase.red) score -= 2;
+      }
+      if (score > bestScore || (score == bestScore && (best == null || sp < best))) {
+        bestScore = score;
+        best = sp;
+      }
+    }
+    return best;
+  }
+
+  static _Phase _phaseAt(Map<String, dynamic> l, DateTime t) {
+    final green = (l['green_sec'] ?? l['main_duration'] ?? 0) as int;
+    final yellow = (l['yellow_sec'] ?? l['ped_duration'] ?? 0) as int;
+    final red = (l['red_sec'] ?? l['side_duration'] ?? 0) as int;
+    final cycle = (l['cycle_total'] as int?) ?? (green + yellow + red);
+    final startStr = l['cycle_start_at'] as String?;
+    final start = startStr != null ? DateTime.parse(startStr).toUtc() : null;
+    if (cycle <= 0 || start == null) return _Phase.unknown;
+    final offset = (l['offset_sec'] as int?) ?? 0;
+    final s = ((t.difference(start).inSeconds + offset) % cycle + cycle) % cycle;
+    if (s < green) return _Phase.green;
+    if (s < green + yellow) return _Phase.yellow;
+    return _Phase.red;
+  }
+}
+
+enum _Phase { green, yellow, red, unknown }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,7 +265,7 @@ packages:
     source: hosted
     version: "2.1.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   geolocator: ^12.0.0
   permission_handler: ^11.4.0
   camera: ^0.10.6
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add OSRM-based route fetching service
- snap traffic lights to route and evaluate speed advice
- allow setting destination on map and display suggested speed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a798a9d2e08323966ab271e4ef862d