### PR TITLE
feat: add theme color picker

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 import '../env.dart';
 import '../main.dart';
+import '../theme_colors.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -25,6 +28,26 @@ class _SettingsScreenState extends State<SettingsScreen> {
             value: themeMode.value == ThemeMode.dark,
             onChanged: (v) => setState(
                 () => themeMode.value = v ? ThemeMode.dark : ThemeMode.light),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            children: [
+              for (final c in themeColors)
+                GestureDetector(
+                  onTap: () async {
+                    setState(() => themeColor.value = c);
+                    final prefs = await SharedPreferences.getInstance();
+                    await prefs.setInt('primary_color', themeColors.indexOf(c));
+                  },
+                  child: CircleAvatar(
+                    backgroundColor: c,
+                    child: themeColor.value == c
+                        ? const Icon(Icons.check, color: Colors.white)
+                        : null,
+                  ),
+                ),
+            ],
           ),
           DropdownButtonFormField<String>(
             value: _lang,

--- a/lib/theme_colors.dart
+++ b/lib/theme_colors.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// Available primary colors for the app theme.
+/// Add more colors to this list to expand palette choices.
+const List<MaterialColor> themeColors = <MaterialColor>[
+  Colors.green,
+  Colors.blue,
+  Colors.red,
+  Colors.purple,
+  Colors.orange,
+  Colors.teal,
+];


### PR DESCRIPTION
## Summary
- add candidate theme color list and persistence
- expose theme color state and apply to app themes
- allow selecting color in settings and update navigation colors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c04430788323b6e1d634924a20e5