### PR TITLE
Add migrations and Supabase models/repos for lights and cycles

### DIFF
--- a/lib/data/models/light.dart
+++ b/lib/data/models/light.dart
@@ -1,0 +1,41 @@
+class Light {
+  final int id;
+  final String? name;
+  final String? intersectionName;
+  final double lat, lon;
+  final List<String> tags;
+  final int? bearingMain;
+  final int? bearingSecondary;
+  Light({
+    required this.id,
+    this.name,
+    this.intersectionName,
+    required this.lat,
+    required this.lon,
+    this.tags = const [],
+    this.bearingMain,
+    this.bearingSecondary,
+  });
+
+  factory Light.fromMap(Map<String, dynamic> m) => Light(
+    id: m['id'] as int,
+    name: m['name'] as String?,
+    intersectionName: m['intersection_name'] as String?,
+    lat: (m['lat'] as num).toDouble(),
+    lon: (m['lon'] as num).toDouble(),
+    tags: (m['tags'] as List?)?.cast<String>() ?? const [],
+    bearingMain: m['bearing_main'] as int?,
+    bearingSecondary: m['bearing_secondary'] as int?,
+  );
+
+  Map<String, dynamic> toInsert(String uid) => {
+    'name': name,
+    'intersection_name': intersectionName,
+    'lat': lat,
+    'lon': lon,
+    'tags': tags,
+    'bearing_main': bearingMain,
+    'bearing_secondary': bearingSecondary,
+    'created_by': uid,
+  };
+}

--- a/lib/data/models/light_cycle.dart
+++ b/lib/data/models/light_cycle.dart
@@ -1,0 +1,53 @@
+class LightCycle {
+  final int id;
+  final int lightId;
+  final String phase; // 'red'|'green'|'yellow'
+  final String dir;   // 'main'|'secondary'|'ped'
+  final DateTime startTs;
+  final DateTime endTs;
+  final String source;
+  final String insertedVia; // 'camera'|'manual'|'import'|'whatif'
+  final double confidence;
+  final String? note;
+
+  LightCycle({
+    required this.id,
+    required this.lightId,
+    required this.phase,
+    required this.dir,
+    required this.startTs,
+    required this.endTs,
+    this.source = 'camera',
+    this.insertedVia = 'camera',
+    this.confidence = 1.0,
+    this.note,
+  });
+
+  factory LightCycle.fromMap(Map<String, dynamic> m) => LightCycle(
+    id: m['id'] as int,
+    lightId: m['light_id'] as int,
+    phase: m['phase'] as String,
+    dir: m['dir'] as String? ?? 'main',
+    startTs: DateTime.parse(m['start_ts'] as String),
+    endTs: DateTime.parse(m['end_ts'] as String),
+    source: m['source'] as String? ?? 'camera',
+    insertedVia: m['inserted_via'] as String? ?? 'camera',
+    confidence: (m['confidence'] as num?)?.toDouble() ?? 1.0,
+    note: m['note'] as String?,
+  );
+
+  Map<String, dynamic> toInsert({
+    required String uid,
+  }) => {
+    'light_id': lightId,
+    'phase': phase,
+    'dir': dir,
+    'start_ts': startTs.toUtc().toIso8601String(),
+    'end_ts': endTs.toUtc().toIso8601String(),
+    'source': source,
+    'inserted_via': insertedVia,
+    'confidence': confidence,
+    'note': note,
+    'created_by': uid,
+  };
+}

--- a/lib/data/repos/cycles_repo.dart
+++ b/lib/data/repos/cycles_repo.dart
@@ -1,0 +1,65 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/light_cycle.dart';
+
+class CyclesRepo {
+  CyclesRepo(this._client);
+  final SupabaseClient _client;
+
+  Future<List<LightCycle>> list({
+    int? lightId,
+    String? dir,
+    DateTime? from,
+    DateTime? to,
+  }) async {
+    final q = _client.from('light_cycles').select();
+    if (lightId != null) q.eq('light_id', lightId);
+    if (dir != null) q.eq('dir', dir);
+    if (from != null) q.gte('start_ts', from.toUtc().toIso8601String());
+    if (to != null) q.lte('start_ts', to.toUtc().toIso8601String());
+    final res = await q.order('start_ts');
+    return (res as List)
+        .map((e) => LightCycle.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<LightCycle?> get(int id) async {
+    final res = await _client
+        .from('light_cycles')
+        .select()
+        .eq('id', id)
+        .maybeSingle();
+    return res == null
+        ? null
+        : LightCycle.fromMap(res as Map<String, dynamic>);
+  }
+
+  Future<LightCycle> insert(LightCycle cycle, {required String uid}) async {
+    final res = await _client
+        .from('light_cycles')
+        .insert(cycle.toInsert(uid: uid))
+        .select()
+        .single();
+    return LightCycle.fromMap(res as Map<String, dynamic>);
+  }
+
+  Future<LightCycle> update(LightCycle cycle) async {
+    final data = {
+      'light_id': cycle.lightId,
+      'phase': cycle.phase,
+      'dir': cycle.dir,
+      'start_ts': cycle.startTs.toUtc().toIso8601String(),
+      'end_ts': cycle.endTs.toUtc().toIso8601String(),
+      'source': cycle.source,
+      'inserted_via': cycle.insertedVia,
+      'confidence': cycle.confidence,
+      'note': cycle.note,
+    };
+    final res = await _client
+        .from('light_cycles')
+        .update(data)
+        .eq('id', cycle.id)
+        .select()
+        .single();
+    return LightCycle.fromMap(res as Map<String, dynamic>);
+  }
+}

--- a/lib/data/repos/lights_repo.dart
+++ b/lib/data/repos/lights_repo.dart
@@ -1,0 +1,48 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/light.dart';
+
+class LightsRepo {
+  LightsRepo(this._client);
+  final SupabaseClient _client;
+
+  Future<List<Light>> list() async {
+    final res = await _client.from('lights').select().order('id');
+    return (res as List)
+        .map((e) => Light.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<Light?> get(int id) async {
+    final res =
+        await _client.from('lights').select().eq('id', id).maybeSingle();
+    return res == null ? null : Light.fromMap(res as Map<String, dynamic>);
+  }
+
+  Future<Light> insert(Light light, {required String uid}) async {
+    final res = await _client
+        .from('lights')
+        .insert(light.toInsert(uid))
+        .select()
+        .single();
+    return Light.fromMap(res as Map<String, dynamic>);
+  }
+
+  Future<Light> update(Light light) async {
+    final data = {
+      'name': light.name,
+      'intersection_name': light.intersectionName,
+      'lat': light.lat,
+      'lon': light.lon,
+      'tags': light.tags,
+      'bearing_main': light.bearingMain,
+      'bearing_secondary': light.bearingSecondary,
+    };
+    final res = await _client
+        .from('lights')
+        .update(data)
+        .eq('id', light.id)
+        .select()
+        .single();
+    return Light.fromMap(res as Map<String, dynamic>);
+  }
+}

--- a/supabase_migration_2025_08_24.sql
+++ b/supabase_migration_2025_08_24.sql
@@ -1,0 +1,24 @@
+-- public.lights: добавить метаданные и теги
+alter table public.lights
+  add column if not exists intersection_name text,
+  add column if not exists tags text[] default '{}',
+  add column if not exists bearing_main smallint,      -- азимут главного направления (0..359)
+  add column if not exists bearing_secondary smallint;  -- азимут второстепенного
+
+-- public.light_cycles: расширить описательность
+alter table public.light_cycles
+  add column if not exists dir text check (dir in ('main','secondary','ped')) default 'main',
+  add column if not exists confidence real default 1.0,     -- достоверность
+  add column if not exists note text,
+  add column if not exists inserted_via text check (inserted_via in ('camera','manual','import','whatif')) default 'camera';
+
+-- ускоряющие индексы
+create index if not exists idx_light_cycles_light_ts on public.light_cycles (light_id, start_ts);
+create index if not exists idx_light_cycles_light_dir on public.light_cycles (light_id, dir);
+
+-- удалить (опционально) todos вместе с политиками
+drop policy if exists "todos read own"   on public.todos;
+drop policy if exists "todos insert own" on public.todos;
+drop policy if exists "todos update own" on public.todos;
+drop policy if exists "todos delete own" on public.todos;
+drop table  if exists public.todos cascade;


### PR DESCRIPTION
## Summary
- add SQL migration to extend lights and light_cycles tables and drop legacy todos
- create Light and LightCycle data models
- add LightsRepo and CyclesRepo with CRUD and filtering helpers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3e76afdc832397b356e6d78ebaef