### PR TITLE
docs: add traffic light schema overview

### DIFF
--- a/docs/traffic_lights.md
+++ b/docs/traffic_lights.md
@@ -1,0 +1,29 @@
+# Traffic light data schema
+
+This project stores traffic light locations and cycle information using Supabase.
+
+## Migrations
+
+`supabase_migration_2025_08_24.sql` updates the database:
+
+- Adds `intersection_name`, `tags`, `bearing_main`, and `bearing_secondary` to `public.lights`.
+- Adds `dir`, `confidence`, `note`, and `inserted_via` to `public.light_cycles`.
+- Creates indexes on `light_cycles` for faster queries.
+- Removes the deprecated `todos` table and its policies.
+
+## Dart models
+
+- [`lib/data/models/light.dart`](../lib/data/models/light.dart) defines a `Light` with
+  id, optional name and intersection name, coordinates, optional bearings, and tags.
+- [`lib/data/models/light_cycle.dart`](../lib/data/models/light_cycle.dart) defines a `LightCycle`
+  including direction, phase, timestamps, source, confidence, and notes.
+
+## Repositories
+
+- [`lib/data/repos/lights_repo.dart`](../lib/data/repos/lights_repo.dart) provides
+  `list`, `get`, `insert`, and `update` operations for lights.
+- [`lib/data/repos/cycles_repo.dart`](../lib/data/repos/cycles_repo.dart) provides
+  `list`, `get`, `insert`, and `update` operations for light cycles and supports
+  filtering by light, direction, and time range.
+
+Run the migration with `supabase db push` to apply these schema changes.


### PR DESCRIPTION
## Summary
- document Supabase schema for traffic light metadata and cycle tracking
- reference Dart models and repositories for lights and light cycles

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa428daa908323a0bd676a89b6a430