### PR TITLE
chore: tidy up duplicated UI code

### DIFF
--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
  
 import '../../screens/lights_screen.dart';
 import '../../screens/map_screen.dart';
+import '../../screens/cycle_recorder.dart';
+import '../../screens/speed_advisor.dart';
 import '../../screens/settings_screen.dart';
 import '../auth/register_page.dart';
 
@@ -22,9 +24,11 @@ class _HomePageState extends State<HomePage> {
     final pages = [
       const MapScreen(),
       const LightsScreen(),
+      const CycleRecorderScreen(),
+      const SpeedAdvisorScreen(),
       const SettingsScreen(),
     ];
-    const titles = ['Карта', 'Светофоры', 'Настройки'];
+    const titles = ['Карта', 'Светофоры', 'Циклы', 'Советчик', 'Настройки'];
 
     return Scaffold(
       appBar: AppBar(
@@ -46,22 +50,11 @@ class _HomePageState extends State<HomePage> {
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Карта'),
           BottomNavigationBarItem(icon: Icon(Icons.traffic), label: 'Светофоры'),
+          BottomNavigationBarItem(icon: Icon(Icons.timelapse), label: 'Циклы'),
+          BottomNavigationBarItem(icon: Icon(Icons.speed), label: 'Советчик'),
           BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Настройки'),
         ],
       ),
-    );
-  }
-}
-
-
-/// Placeholder home page shown after authentication.
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Home')), // TODO: implement real home page
     );
   }
 }

--- a/lib/screens/cycle_recorder.dart
+++ b/lib/screens/cycle_recorder.dart
@@ -229,8 +229,6 @@ class _CycleRecorderScreenState extends State<CycleRecorderScreen> {
   @override
   Widget build(BuildContext context) {
     final disableAnimations = MediaQuery.of(context).disableAnimations;
-    final btnStyle =
-        disableAnimations ? ElevatedButton.styleFrom(elevation: 0) : null;
     final ratio = _cam != null && _camReady ? _cam!.value.aspectRatio : 16 / 9;
     return Scaffold(
       appBar: AppBar(title: const Text("Cycle Recorder")),
@@ -255,30 +253,6 @@ class _CycleRecorderScreenState extends State<CycleRecorderScreen> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
             child: Wrap(spacing: 8, children: [
- 
-              ElevatedButton(
-                  onPressed: () => _markPhase("red"),
-                  style: btnStyle,
-                  child: const Text("Red")),
-              ElevatedButton(
-                  onPressed: () => _markPhase("yellow"),
-                  style: btnStyle,
-                  child: const Text("Yellow")),
-              ElevatedButton(
-                  onPressed: () => _markPhase("green"),
-                  style: btnStyle,
-                  child: const Text("Green")),
-              OutlinedButton(
-                  onPressed: _stopAndUpload,
-                  child: const Text("Stop & Upload")),
-              OutlinedButton(
-                  onPressed: _markHere, child: const Text("Mark here")),
-              ElevatedButton(
-                  onPressed: _toggleAuto,
-                  style: btnStyle,
-                  child: Text(
-                      _autoDetect ? "Auto Detect: ON" : "Auto Detect: OFF")),
-
               GlowingButton(
                   onPressed: () => _markPhase("red"),
                   text: "Red",
@@ -302,7 +276,6 @@ class _CycleRecorderScreenState extends State<CycleRecorderScreen> {
               GlowingButton(
                   onPressed: _toggleAuto,
                   text: _autoDetect ? "Auto Detect: ON" : "Auto Detect: OFF"),
- 
             ]),
           ),
           Expanded(

--- a/lib/screens/lights_screen.dart
+++ b/lib/screens/lights_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
- 
 
- 
 import '../main.dart';
 
 /// Simple list of traffic lights loaded from Supabase.
@@ -42,7 +40,6 @@ class _LightsScreenState extends State<LightsScreen> {
 
   @override
   Widget build(BuildContext context) {
- 
     final l10n = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(title: Text(l10n.lightsTitle)),
@@ -57,33 +54,12 @@ class _LightsScreenState extends State<LightsScreen> {
             final subtitle =
                 (lat != null && lon != null) ? '$lat, $lon' : l10n.noCoords;
             return ListTile(
-              title: Text(l['name'] as String? ??
-                  l10n.lightWithId(l['id'].toString())),
+              title: Text(
+                  l['name'] as String? ?? l10n.lightWithId(l['id'].toString())),
               subtitle: Text(subtitle),
             );
           },
         ),
-
-      final loc = AppLocalizations.of(context)!;
-      return Scaffold(
-        appBar: AppBar(title: Text(loc.lights)),
-        body: RefreshIndicator(
-        onRefresh: _load,
-          child: ListView.builder(
-            itemCount: _items.length,
-            itemBuilder: (c, i) {
-              final item = _items[i];
-              final lat = (item['lat'] as num?)?.toDouble();
-              final lon = (item['lon'] as num?)?.toDouble();
-              final subtitle =
-                  (lat != null && lon != null) ? '$lat, $lon' : loc.noCoords;
-              return ListTile(
-                title: Text(item['name'] as String? ?? 'Light ${item['id']}'),
-                subtitle: Text(subtitle),
-              );
-            },
-          ),
- 
       ),
     );
   }

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -6,7 +6,6 @@ import 'package:latlong2/latlong.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:camera/camera.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../services/route_service.dart';
 import '../services/snap_utils.dart';

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-
 import '../env.dart';
 import '../main.dart';
 import '../shared/constants/app_colors.dart';
@@ -21,7 +19,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
- 
     final l10n = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(title: Text(l10n.settingsTitle)),
@@ -34,20 +31,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
             onChanged: (v) => setState(
                 () => themeMode.value = v ? ThemeMode.dark : ThemeMode.light),
           ),
-
-      final l = AppLocalizations.of(context)!;
-      return Scaffold(
-        appBar: AppBar(title: Text(l.settings)),
-        body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-            SwitchListTile(
-              title: Text(l.darkTheme),
-              value: themeMode.value == ThemeMode.dark,
-              onChanged: (v) => setState(
-                  () => themeMode.value = v ? ThemeMode.dark : ThemeMode.light),
-            ),
- 
           const SizedBox(height: 12),
           Wrap(
             spacing: 8,
@@ -57,12 +40,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   onTap: () async {
                     setState(() => themeColor.value = c);
                     final prefs = await SharedPreferences.getInstance();
- 
                     await prefs.setInt(
                         'primary_color', AppColors.themeColors.indexOf(c));
-
-                    await prefs.setInt('primary_color', AppColors.themeColors.indexOf(c));
- 
                   },
                   child: CircleAvatar(
                     backgroundColor: c,
@@ -73,7 +52,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
             ],
           ),
- 
           DropdownButtonFormField<String>(
             value: _lang,
             items: [
@@ -94,35 +72,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
             decoration: InputDecoration(labelText: l10n.supabaseKey),
             obscureText: true,
           ),
-
-            DropdownButtonFormField<String>(
-              value: _lang,
-              items: [
-                DropdownMenuItem(value: 'en', child: Text('English')),
-                DropdownMenuItem(value: 'ru', child: const Text('Русский')),
-              ],
-              onChanged: (v) => setState(() => _lang = v ?? 'en'),
-              decoration:
-                  InputDecoration(labelText: l.language, hintText: l.language),
-            ),
-          const SizedBox(height: 16),
-            TextField(
-              controller: _urlCtrl,
-              decoration: InputDecoration(
-                labelText: l.supabaseUrl,
-                hintText: l.supabaseUrl,
-              ),
-            ),
-          const SizedBox(height: 12),
-            TextField(
-              controller: _keyCtrl,
-              decoration: InputDecoration(
-                labelText: l.supabaseKey,
-                hintText: l.supabaseKey,
-              ),
-              obscureText: true,
-            ),
- 
         ],
       ),
     );

--- a/lib/screens/speed_advisor.dart
+++ b/lib/screens/speed_advisor.dart
@@ -222,11 +222,6 @@ class _SpeedAdvisorScreenState extends State<SpeedAdvisorScreen> {
             ),
             const SizedBox(height: 8),
  
-            ElevatedButton(
-                onPressed: _compute,
-                style: btnStyle,
-                child: const Text("Compute advice")),
-
             GlowingButton(
               onPressed: _compute,
               text: "Compute advice",


### PR DESCRIPTION
## Summary
- clean up HomePage and add navigation tabs for cycles and advisor
- remove duplicated widget code in lights and settings screens
- simplify cycle recorder and speed advisor actions with GlowingButtons

## Testing
- `dart format lib/features/home/home_page.dart lib/screens/lights_screen.dart lib/screens/settings_screen.dart lib/screens/map_screen.dart lib/screens/speed_advisor.dart lib/screens/cycle_recorder.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4601cfa88323a2bf4cd87df17808