### PR TITLE
feat: add manual stopwatch and frame import

### DIFF
--- a/lib/screens/cycles_screen.dart
+++ b/lib/screens/cycles_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'manual_stopwatch.dart';
+import 'frame_import.dart';
 
 class CyclesScreen extends StatefulWidget {
   const CyclesScreen({super.key});
@@ -280,6 +282,30 @@ class _CyclesScreenState extends State<CyclesScreen>
                               ? null
                               : () => _whatIf(_dirs[i]),
                           child: const Text('Что-если')),
+                      const SizedBox(height: 12),
+                      ElevatedButton(
+                          onPressed: _lightId == null
+                              ? null
+                              : () => Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (_) => ManualStopwatchScreen(
+                                            lightId: _lightId!,
+                                            dir: _dirs[i],
+                                          ))),
+                          child: const Text('Секундомер')),
+                      const SizedBox(height: 12),
+                      ElevatedButton(
+                          onPressed: _lightId == null
+                              ? null
+                              : () => Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (_) => FrameImportScreen(
+                                            lightId: _lightId!,
+                                            dir: _dirs[i],
+                                          ))),
+                          child: const Text('Импорт кадров')),
                     ],
                   ),
                 ),

--- a/lib/screens/frame_import.dart
+++ b/lib/screens/frame_import.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class FrameImportScreen extends StatefulWidget {
+  final int lightId;
+  final String dir;
+  const FrameImportScreen({super.key, required this.lightId, required this.dir});
+
+  @override
+  State<FrameImportScreen> createState() => _FrameImportScreenState();
+}
+
+class _FrameImportScreenState extends State<FrameImportScreen> {
+  final _supa = Supabase.instance.client;
+  final _frames = <_FrameItem>[];
+  double _offset = 0;
+  double _confidence = 0.9;
+
+  Future<void> _pick() async {
+    final res = await FilePicker.platform.pickFiles(
+      allowMultiple: true,
+      type: FileType.custom,
+      allowedExtensions: ['jpg', 'jpeg', 'png'],
+    );
+    if (res == null) return;
+    for (final f in res.files) {
+      final path = f.path;
+      if (path == null) continue;
+      final name = path.split(RegExp(r'[\\/]')).last;
+      final parsed = _parseName(name);
+      if (parsed.ts == null) continue;
+      String? phase = parsed.phase;
+      if (phase == null) {
+        phase = await _askPhase(name);
+        if (phase == null) continue;
+      }
+      _frames.add(_FrameItem(ts: parsed.ts!, phase: phase));
+    }
+    _frames.sort((a, b) => a.ts.compareTo(b.ts));
+    setState(() {});
+  }
+
+  Future<String?> _askPhase(String name) async {
+    String ph = 'green';
+    return showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Phase for $name'),
+        content: DropdownButton<String>(
+          value: ph,
+          items: const [
+            DropdownMenuItem(value: 'green', child: Text('Green')),
+            DropdownMenuItem(value: 'yellow', child: Text('Yellow')),
+            DropdownMenuItem(value: 'red', child: Text('Red')),
+          ],
+          onChanged: (v) => ph = v ?? 'green',
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(ctx, ph), child: const Text('OK')),
+        ],
+      ),
+    );
+  }
+
+  _ParsedName _parseName(String name) {
+    final lower = name.toLowerCase();
+    DateTime? ts;
+    String? phase;
+    final rx1 = RegExp(r'(\d{8})[_-](\d{6})(?:_\d+)?(?:_([a-z]+))?(?:_([a-z]+))?');
+    final m1 = rx1.firstMatch(lower);
+    if (m1 != null) {
+      final date = m1.group(1)!;
+      final time = m1.group(2)!;
+      ts = DateTime(
+        int.parse(date.substring(0, 4)),
+        int.parse(date.substring(4, 6)),
+        int.parse(date.substring(6, 8)),
+        int.parse(time.substring(0, 2)),
+        int.parse(time.substring(2, 4)),
+        int.parse(time.substring(4, 6)),
+      );
+      phase = _extractPhase([m1.group(3), m1.group(4)]);
+    } else {
+      final rx2 = RegExp(r'(\d{2})-(\d{2})-(\d{2})');
+      final m2 = rx2.firstMatch(lower);
+      if (m2 != null) {
+        final now = DateTime.now();
+        ts = DateTime(now.year, now.month, now.day,
+            int.parse(m2.group(1)!), int.parse(m2.group(2)!), int.parse(m2.group(3)!));
+      }
+      phase = _extractPhase([null]);
+    }
+    return _ParsedName(ts: ts, phase: phase);
+  }
+
+  String? _extractPhase(List<String?> parts) {
+    for (final p in parts) {
+      if (p == 'red' || p == 'green' || p == 'yellow') return p;
+    }
+    final phMatch = RegExp(r'_(red|green|yellow)').firstMatch(parts.first ?? '');
+    return phMatch?.group(1);
+  }
+
+  Future<void> _save() async {
+    if (_frames.isEmpty) return;
+    final uid = _supa.auth.currentUser?.id;
+    if (uid == null) return;
+    final rows = <Map<String, dynamic>>[];
+    final offsetDur = Duration(seconds: _offset.round());
+    for (int i = 0; i < _frames.length; i++) {
+      final start = _frames[i].ts.add(offsetDur);
+      final end = (i + 1 < _frames.length
+              ? _frames[i + 1].ts
+              : _frames[i].ts.add(const Duration(seconds: 1)))
+          .add(offsetDur);
+      rows.add({
+        'light_id': widget.lightId,
+        'dir': widget.dir,
+        'phase': _frames[i].phase,
+        'start_ts': start.toUtc().toIso8601String(),
+        'end_ts': end.toUtc().toIso8601String(),
+        'source': 'import',
+        'inserted_via': 'import',
+        'confidence': _confidence,
+        'created_by': uid,
+      });
+    }
+    await _supa.from('light_cycles').insert(rows);
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Imported')));
+      setState(() => _frames.clear());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Import Frames')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    decoration: const InputDecoration(labelText: 'Camera offset (sec)'),
+                    keyboardType: TextInputType.number,
+                    onChanged: (v) => _offset = double.tryParse(v) ?? 0,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(onPressed: _pick, child: const Text('Import')),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Row(
+              children: [
+                const Text('Confidence'),
+                Expanded(
+                  child: Slider(
+                    value: _confidence,
+                    min: 0.5,
+                    max: 1.0,
+                    divisions: 5,
+                    label: _confidence.toStringAsFixed(2),
+                    onChanged: (v) => setState(() => _confidence = v),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _frames.length,
+              itemBuilder: (c, i) {
+                final f = _frames[i];
+                return ListTile(
+                  title: DropdownButton<String>(
+                    value: f.phase,
+                    items: const [
+                      DropdownMenuItem(value: 'green', child: Text('Green')),
+                      DropdownMenuItem(value: 'yellow', child: Text('Yellow')),
+                      DropdownMenuItem(value: 'red', child: Text('Red')),
+                    ],
+                    onChanged: (v) => setState(() => f.phase = v ?? f.phase),
+                  ),
+                  subtitle: Text(f.ts.toLocal().toString()),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: ElevatedButton(onPressed: _save, child: const Text('Save')),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FrameItem {
+  DateTime ts;
+  String phase;
+  _FrameItem({required this.ts, required this.phase});
+}
+
+class _ParsedName {
+  final DateTime? ts;
+  final String? phase;
+  _ParsedName({this.ts, this.phase});
+}
+

--- a/lib/screens/manual_stopwatch.dart
+++ b/lib/screens/manual_stopwatch.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class ManualStopwatchScreen extends StatefulWidget {
+  final int lightId;
+  final String dir;
+  const ManualStopwatchScreen({super.key, required this.lightId, required this.dir});
+
+  @override
+  State<ManualStopwatchScreen> createState() => _ManualStopwatchScreenState();
+}
+
+class _ManualStopwatchScreenState extends State<ManualStopwatchScreen> {
+  final _supa = Supabase.instance.client;
+  bool _running = false;
+  String? _curPhase;
+  DateTime? _curStart;
+  final List<Map<String, dynamic>> _segments = [];
+
+  void _start() {
+    _segments.clear();
+    _curPhase = null;
+    _curStart = DateTime.now();
+    _running = true;
+    setState(() {});
+  }
+
+  void _mark(String phase) {
+    if (!_running) return;
+    final now = DateTime.now();
+    if (_curPhase != null && _curStart != null) {
+      _segments.add({'phase': _curPhase, 'start': _curStart, 'end': now});
+    }
+    _curPhase = phase;
+    _curStart = now;
+    setState(() {});
+  }
+
+  void _stop() {
+    if (!_running) return;
+    final now = DateTime.now();
+    if (_curPhase != null && _curStart != null) {
+      _segments.add({'phase': _curPhase, 'start': _curStart, 'end': now});
+    }
+    _curPhase = null;
+    _curStart = null;
+    _running = false;
+    setState(() {});
+  }
+
+  Future<void> _save() async {
+    final uid = _supa.auth.currentUser?.id;
+    if (uid == null || _segments.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Nothing to save')));
+      }
+      return;
+    }
+    final rows = _segments
+        .map((s) => {
+              'light_id': widget.lightId,
+              'phase': s['phase'],
+              'dir': widget.dir,
+              'start_ts': (s['start'] as DateTime).toUtc().toIso8601String(),
+              'end_ts': (s['end'] as DateTime).toUtc().toIso8601String(),
+              'source': 'manual',
+              'inserted_via': 'manual',
+              'confidence': 1.0,
+              'created_by': uid,
+            })
+        .toList();
+    await _supa.from('light_cycles').insert(rows);
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Saved')));
+      setState(() {
+        _segments.clear();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Stopwatch')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Text('Light ${widget.lightId}, dir ${widget.dir}'),
+          ),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            alignment: WrapAlignment.center,
+            children: [
+              ElevatedButton(
+                  onPressed: _start,
+                  style: ElevatedButton.styleFrom(minimumSize: const Size(120, 60)),
+                  child: const Text('Start')),
+              ElevatedButton(
+                  onPressed: () => _mark('green'),
+                  style: ElevatedButton.styleFrom(minimumSize: const Size(120, 60)),
+                  child: const Text('Green')),
+              ElevatedButton(
+                  onPressed: () => _mark('yellow'),
+                  style: ElevatedButton.styleFrom(minimumSize: const Size(120, 60)),
+                  child: const Text('Yellow')),
+              ElevatedButton(
+                  onPressed: () => _mark('red'),
+                  style: ElevatedButton.styleFrom(minimumSize: const Size(120, 60)),
+                  child: const Text('Red')),
+              ElevatedButton(
+                  onPressed: _stop,
+                  style: ElevatedButton.styleFrom(minimumSize: const Size(120, 60)),
+                  child: const Text('Stop')),
+              ElevatedButton(
+                  onPressed: _save,
+                  style: ElevatedButton.styleFrom(minimumSize: const Size(120, 60)),
+                  child: const Text('Save')),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _segments.length,
+              itemBuilder: (c, i) {
+                final s = _segments[i];
+                return ListTile(
+                  title: Text('${s['phase']}'),
+                  subtitle: Text(
+                      '${(s['start'] as DateTime).toLocal()} -> ${(s['end'] as DateTime).toLocal()}'),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   camera: ^0.10.6
   http: ^1.2.1
   shared_preferences: ^2.2.2
+  file_picker: ^5.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add manual stopwatch screen to record light phases manually
- allow importing timestamped frames to create light cycle entries
- expose new tools from cycles screen and add file picker dependency

## Testing
- `flutter pub get` (fails: command not found)
- `dart analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa48bf5aa08323b1b7f6608a3cbd96