### PR TITLE
feat: add speed advisor service

### DIFF
--- a/lib/domain/green_windows_service.dart
+++ b/lib/domain/green_windows_service.dart
@@ -1,0 +1,81 @@
+import 'dart:math';
+
+import '../data/repos/cycles_repo.dart';
+import '../data/models/light_cycle.dart';
+
+/// Service that predicts upcoming green windows for a traffic light.
+class GreenWindowsService {
+  GreenWindowsService(this._cycles);
+
+  final CyclesRepo _cycles;
+
+  /// Returns upcoming green windows relative to [now] in seconds.
+  ///
+  /// The service fetches last [history] green cycles for [lightId] and [dir],
+  /// builds a typical period using median of intervals between cycles and uses
+  /// the last observed start as an anchor. 2-3 windows ahead are returned.
+  Future<List<({double tStart, double tEnd})>> fetch({
+    required int lightId,
+    required String dir,
+    required DateTime now,
+    int history = 5,
+    int forward = 3,
+  }) async {
+    // Fetch recent cycles from repo. We request several hours back to ensure
+    // enough data and then keep only the latest [history] green cycles.
+    final from = now.subtract(const Duration(hours: 6));
+    final cycles = await _cycles.list(
+      lightId: lightId,
+      dir: dir,
+      from: from,
+      to: now,
+    );
+    final greens = cycles.where((c) => c.phase.toLowerCase() == 'green').toList();
+    if (greens.length < 2) return [];
+    final recent = greens.sublist(max(0, greens.length - history));
+
+    // Green duration for each cycle.
+    final lengths = recent
+        .map((c) => c.endTs.difference(c.startTs).inSeconds.toDouble())
+        .toList();
+    final tGreen = _median(lengths);
+
+    // Period between start of subsequent green cycles.
+    final intervals = <double>[];
+    for (int i = 1; i < recent.length; i++) {
+      intervals.add(
+        recent[i]
+            .startTs
+            .difference(recent[i - 1].startTs)
+            .inSeconds
+            .toDouble(),
+      );
+    }
+    var period = _median(intervals);
+    if (period <= 0) period = intervals.isNotEmpty ? intervals.last : 60;
+
+    // Anchor on last observed green start and project forward.
+    var nextStart = recent.last.startTs;
+    while (nextStart.isBefore(now)) {
+      nextStart = nextStart.add(Duration(seconds: period.round()));
+    }
+
+    final res = <({double tStart, double tEnd})>[];
+    for (int i = 0; i < forward; i++) {
+      final s = nextStart.add(Duration(seconds: (period * i).round()));
+      final e = s.add(Duration(seconds: tGreen.round()));
+      res.add((
+        tStart: s.difference(now).inSeconds.toDouble(),
+        tEnd: e.difference(now).inSeconds.toDouble(),
+      ));
+    }
+    return res;
+  }
+
+  double _median(List<double> v) {
+    if (v.isEmpty) return 0;
+    final s = [...v]..sort();
+    final mid = s.length ~/ 2;
+    return s.length.isOdd ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+  }
+}

--- a/lib/domain/speed_advisor.dart
+++ b/lib/domain/speed_advisor.dart
@@ -1,0 +1,56 @@
+import 'dart:math';
+
+/// Suggests a target speed to reach one of the upcoming green windows.
+double adviseSpeedKmh({
+  required double distanceM,
+  required double currentKmh,
+  required List<({double tStart, double tEnd})> windows,
+  double limitKmh = 70,
+  double dtSec = 1.0,
+}) {
+  const minKmh = 25.0; // search range
+  const minRollKmh = 20.0;
+  final maxKmh = min(limitKmh, 70.0);
+
+  // physical limits (approx.):
+  const accelLimit = 7.2; // km/h per second (~2 m/s^2)
+  const decelLimit = 10.8; // km/h per second (~3 m/s^2)
+  const emaAlpha = 0.5;
+  const deadband = 0.5;
+
+  double? target;
+  for (final w in windows) {
+    if (w.tEnd <= 0) continue;
+    final vMin = distanceM / w.tEnd * 3.6; // km/h
+    final vMax = distanceM / w.tStart * 3.6; // km/h
+    final low = max(minKmh, vMin);
+    final high = min(maxKmh, vMax);
+    if (low <= high) {
+      if (currentKmh < low) {
+        target = low;
+      } else if (currentKmh > high) {
+        target = high;
+      } else {
+        target = currentKmh;
+      }
+      break;
+    }
+  }
+  target ??= max(minKmh, min(maxKmh, currentKmh));
+
+  var delta = target - currentKmh;
+  if (delta > 0) {
+    delta = min(delta, accelLimit * dtSec);
+  } else {
+    delta = max(delta, -decelLimit * dtSec);
+  }
+  var next = currentKmh + delta;
+  // EMA smoothing
+  next = emaAlpha * next + (1 - emaAlpha) * currentKmh;
+  // deadband to prevent jitter
+  if ((next - currentKmh).abs() < deadband) {
+    next = currentKmh;
+  }
+  next = next.clamp(minRollKmh, maxKmh);
+  return next.roundToDouble();
+}

--- a/lib/widgets/speed_advice_panel.dart
+++ b/lib/widgets/speed_advice_panel.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../domain/speed_advisor.dart';
+
+/// Simple UI panel that displays recommended speed and upcoming windows.
+class SpeedAdvicePanel extends StatelessWidget {
+  const SpeedAdvicePanel({
+    super.key,
+    required this.distanceM,
+    required this.currentKmh,
+    required this.windows,
+    this.limitKmh = 70,
+  });
+
+  final double distanceM;
+  final double currentKmh;
+  final List<({double tStart, double tEnd})> windows;
+  final double limitKmh;
+
+  @override
+  Widget build(BuildContext context) {
+    final rec = adviseSpeedKmh(
+      distanceM: distanceM,
+      currentKmh: currentKmh,
+      windows: windows,
+      limitKmh: limitKmh,
+    );
+
+    // crude progress estimation to stop line (0..1)
+    final progress = (1 - distanceM / 200).clamp(0.0, 1.0);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.black.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Рекомендуем: ${rec.toStringAsFixed(0)} км/ч',
+            style: Theme.of(context)
+                .textTheme
+                .headlineMedium
+                ?.copyWith(color: Colors.white, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          LinearProgressIndicator(
+            value: progress,
+            backgroundColor: Colors.white24,
+            valueColor: const AlwaysStoppedAnimation<Color>(Colors.green),
+            minHeight: 4,
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 4,
+            runSpacing: 4,
+            children: windows.map(_buildWindowChip).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWindowChip(({double tStart, double tEnd}) w) {
+    final reachable = _windowReachable(w);
+    final text = 'через ${w.tStart.round()}с → ${(w.tEnd - w.tStart).round()}с зелёный';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        gradient: reachable
+            ? const LinearGradient(colors: [Colors.green, Colors.lightGreen])
+            : null,
+        color: reachable ? null : Colors.grey.shade600,
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(color: Colors.white),
+      ),
+    );
+  }
+
+  bool _windowReachable(({double tStart, double tEnd}) w) {
+    final vMin = distanceM / w.tEnd * 3.6;
+    final vMax = distanceM / w.tStart * 3.6;
+    return vMin <= limitKmh && vMax >= 25;
+  }
+}


### PR DESCRIPTION
## Summary
- add service to predict upcoming green windows from historical cycles
- add smooth speed advisor with acceleration limits and 1 km/h steps
- add UI panel widget displaying recommended speed and green windows

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a0efdf883239a63ee674e224432