### PR TITLE
feat: add settings and permissions

### DIFF
--- a/lib/features/auth/register_page.dart
+++ b/lib/features/auth/register_page.dart
@@ -249,22 +249,12 @@ class _RegisterPageState extends State<RegisterPage> {
               ElevatedButton(
                 onPressed: () => _oauthLogin(Provider.google),
                 child: const Text('Sign in with Google'),
-              )
-            else
-              const GlowingButton(
-                onPressed: null,
-                child: Text('TODO: Google OAuth'),
               ),
             const SizedBox(height: 12),
             if (appleEnabled)
               ElevatedButton(
                 onPressed: () => _oauthLogin(Provider.apple),
                 child: const Text('Sign in with Apple'),
-              )
-            else
-              const GlowingButton(
-                onPressed: null,
-                child: Text('TODO: Apple OAuth'),
               ),
           ],
         ),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -47,7 +47,11 @@
   "adviceTitle": "Speed advice",
   "notEnoughData": "Not enough data. Ride with camera autolog.",
   "cycleInfo": "Cycle {cycle}s (R {red} / Y {yellow} / G {green})",
-  "holdSpeed": "Keep ~ {low}–{high} km/h"
+  "holdSpeed": "Keep ~ {low}–{high} km/h",
+  "unitsKmh": "Units",
+  "roadSpeedLimit": "Road speed limit (km/h)",
+  "cameraOffset": "Camera clock offset (s)",
+  "jerkStep": "Advisor jerk step"
   "@@locale": "en",
   "appTitle": "GreenWave",
   "map": "Map",

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -47,7 +47,11 @@
   "adviceTitle": "Подсказка скорости",
   "notEnoughData": "Недостаточно данных. Прокатись с автологом камеры.",
   "cycleInfo": "Цикл {cycle}с (R {red} / Y {yellow} / G {green})",
-  "holdSpeed": "Держите ~ {low}–{high} км/ч"
+  "holdSpeed": "Держите ~ {low}–{high} км/ч",
+  "unitsKmh": "Единицы",
+  "roadSpeedLimit": "Лимит скорости дороги (км/ч)",
+  "cameraOffset": "Смещение часов камеры (с)",
+  "jerkStep": "Шаг jerk советчика"
 
   "@@locale": "ru",
   "appTitle": "GreenWave",

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -38,6 +38,7 @@ class _MapScreenState extends State<MapScreen> {
   @override
   void initState() {
     super.initState();
+    _ensurePermission();
     _loadLights();
     _updateNearest();
     _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -99,7 +100,18 @@ class _MapScreenState extends State<MapScreen> {
     } catch (_) {}
   }
 
+  Future<bool> _ensurePermission() async {
+    var perm = await Geolocator.checkPermission();
+    if (perm == LocationPermission.denied) {
+      perm = await Geolocator.requestPermission();
+    }
+    return perm == LocationPermission.always ||
+        perm == LocationPermission.whileInUse;
+  }
+
   Future<LatLng> _currentPos() async {
+    final ok = await _ensurePermission();
+    if (!ok) return _map.center;
     try {
       final p = await Geolocator.getCurrentPosition();
       return LatLng(p.latitude, p.longitude);

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -16,6 +16,40 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String _lang = 'en';
   final _urlCtrl = TextEditingController(text: Env.supabaseUrl);
   final _keyCtrl = TextEditingController(text: Env.supabaseAnonKey);
+  String _units = 'kmh';
+  double _speedLimit = 60;
+  double _camOffset = 0;
+  double _jerkStep = 1;
+  final _speedCtrl = TextEditingController();
+  final _offsetCtrl = TextEditingController();
+  final _jerkCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrefs();
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _units = prefs.getString('units') ?? 'kmh';
+      _speedLimit = prefs.getDouble('speed_limit') ?? 60;
+      _camOffset = prefs.getDouble('cam_offset') ?? 0;
+      _jerkStep = prefs.getDouble('jerk_step') ?? 1;
+      _speedCtrl.text = _speedLimit.toString();
+      _offsetCtrl.text = _camOffset.toString();
+      _jerkCtrl.text = _jerkStep.toString();
+    });
+  }
+
+  Future<void> _savePrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('units', _units);
+    await prefs.setDouble('speed_limit', _speedLimit);
+    await prefs.setDouble('cam_offset', _camOffset);
+    await prefs.setDouble('jerk_step', _jerkStep);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,6 +64,49 @@ class _SettingsScreenState extends State<SettingsScreen> {
             value: themeMode.value == ThemeMode.dark,
             onChanged: (v) => setState(
                 () => themeMode.value = v ? ThemeMode.dark : ThemeMode.light),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            value: _units,
+            items: const [
+              DropdownMenuItem(value: 'kmh', child: Text('km/h')),
+              DropdownMenuItem(value: 'mph', child: Text('mph')),
+            ],
+            onChanged: (v) {
+              setState(() => _units = v ?? 'kmh');
+              _savePrefs();
+            },
+            decoration: InputDecoration(labelText: l10n.unitsKmh),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _speedCtrl,
+            decoration: InputDecoration(labelText: l10n.roadSpeedLimit),
+            keyboardType: TextInputType.number,
+            onChanged: (v) {
+              _speedLimit = double.tryParse(v) ?? _speedLimit;
+              _savePrefs();
+            },
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _offsetCtrl,
+            decoration: InputDecoration(labelText: l10n.cameraOffset),
+            keyboardType: TextInputType.number,
+            onChanged: (v) {
+              _camOffset = double.tryParse(v) ?? _camOffset;
+              _savePrefs();
+            },
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _jerkCtrl,
+            decoration: InputDecoration(labelText: l10n.jerkStep),
+            keyboardType: TextInputType.number,
+            onChanged: (v) {
+              _jerkStep = double.tryParse(v) ?? _jerkStep;
+              _savePrefs();
+            },
           ),
           const SizedBox(height: 12),
           Wrap(
@@ -72,8 +149,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
             decoration: InputDecoration(labelText: l10n.supabaseKey),
             obscureText: true,
           ),
-        ],
+      ],
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    _urlCtrl.dispose();
+    _keyCtrl.dispose();
+    _speedCtrl.dispose();
+    _offsetCtrl.dispose();
+    _jerkCtrl.dispose();
+    super.dispose();
   }
 }

--- a/linux/flutter/CMakeLists.txt
+++ b/linux/flutter/CMakeLists.txt
@@ -6,8 +6,6 @@ set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 # Configuration provided via flutter tool.
 include(${EPHEMERAL_DIR}/generated_config.cmake)
 
-# TODO: Move the rest of this into files in ephemeral. See
-# https://github.com/flutter/flutter/issues/57146.
 
 # Serves the same purpose as list(TRANSFORM ... PREPEND ...),
 # which isn't available in 3.10.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,9 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
- 
-  intl: ^0.18.0
 
   intl: ^0.18.1
- 
+
   flutter_map: ^6.2.1
   latlong2: ^0.9.1
   supabase_flutter: ^2.6.0
@@ -24,6 +22,8 @@ dependencies:
   http: ^1.2.1
   shared_preferences: ^2.2.2
   file_picker: ^5.3.2
+  path_provider: ^2.1.3
+  flutter_riverpod: ^2.4.9
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/CMakeLists.txt
+++ b/windows/flutter/CMakeLists.txt
@@ -6,8 +6,6 @@ set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 # Configuration provided via flutter tool.
 include(${EPHEMERAL_DIR}/generated_config.cmake)
 
-# TODO: Move the rest of this into files in ephemeral. See
-# https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
 # Set fallback configurations for older versions of the flutter tool.


### PR DESCRIPTION
## Summary
- request location permission on map load and "center on me"
- expand settings with units, speed limit, camera offset, and jerk step
- remove TODO OAuth placeholders

## Testing
- ❌ `flutter pub get` (flutter not installed)
- ❌ `flutter gen-l10n` (flutter not installed)
- ❌ `dart format` (dart not installed)
- ❌ `flutter test` (flutter not installed)


------
https://chatgpt.com/codex/tasks/task_e_68aa4bce92b0832393449ab63e77e09f