### PR TITLE
chore: migrate l10n config

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,7 +1,7 @@
 arb-dir: lib/l10n
 template-arb-file: intl_en.arb
 output-localization-file: app_localizations.dart
-synthetic-package: true
+output-dir: lib/l10n/generated
 nullable-getter: false
 preferred-supported-locales:
   - en

--- a/lib/features/auth/presentation/register_page.dart
+++ b/lib/features/auth/presentation/register_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class RegisterPage extends StatefulWidget {
@@ -15,8 +15,9 @@ class RegisterPage extends StatefulWidget {
       );
     } catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Error: ' + e.toString())));
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Error: ' + e.toString())));
       }
     }
   }
@@ -41,8 +42,9 @@ class _RegisterPageState extends State<RegisterPage> {
       );
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Error: ' + e.toString())));
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Error: ' + e.toString())));
       }
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -58,8 +60,9 @@ class _RegisterPageState extends State<RegisterPage> {
       );
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Error: ' + e.toString())));
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Error: ' + e.toString())));
       }
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -106,8 +109,9 @@ class _RegisterPageState extends State<RegisterPage> {
               ],
             ),
             TextButton(
-              onPressed:
-                  _busy ? null : () => setState(() => _isLogin = !_isLogin),
+              onPressed: _busy
+                  ? null
+                  : () => setState(() => _isLogin = !_isLogin),
               child: Text(_isLogin ? l10n.createAccount : l10n.haveAccount),
             ),
           ],
@@ -116,4 +120,3 @@ class _RegisterPageState extends State<RegisterPage> {
     );
   }
 }
-

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1,0 +1,488 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+import 'app_localizations_ru.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'generated/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
+    Locale('ru'),
+  ];
+
+  /// App title on the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'GreenWave'**
+  String get appTitle;
+
+  /// No description provided for @navMap.
+  ///
+  /// In en, this message translates to:
+  /// **'Map'**
+  String get navMap;
+
+  /// No description provided for @navLights.
+  ///
+  /// In en, this message translates to:
+  /// **'Lights'**
+  String get navLights;
+
+  /// No description provided for @navSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get navSettings;
+
+  /// No description provided for @map.
+  ///
+  /// In en, this message translates to:
+  /// **'Map'**
+  String get map;
+
+  /// No description provided for @lights.
+  ///
+  /// In en, this message translates to:
+  /// **'Lights'**
+  String get lights;
+
+  /// No description provided for @settings.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settings;
+
+  /// No description provided for @signIn.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign in'**
+  String get signIn;
+
+  /// No description provided for @signUp.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign up'**
+  String get signUp;
+
+  /// No description provided for @createAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'Create account'**
+  String get createAccount;
+
+  /// No description provided for @haveAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'I have an account'**
+  String get haveAccount;
+
+  /// No description provided for @email.
+  ///
+  /// In en, this message translates to:
+  /// **'Email'**
+  String get email;
+
+  /// No description provided for @password.
+  ///
+  /// In en, this message translates to:
+  /// **'Password'**
+  String get password;
+
+  /// No description provided for @emailLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Email'**
+  String get emailLabel;
+
+  /// No description provided for @passwordLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Password'**
+  String get passwordLabel;
+
+  /// No description provided for @emailHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your email'**
+  String get emailHint;
+
+  /// No description provided for @passwordHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your password'**
+  String get passwordHint;
+
+  /// No description provided for @slogan.
+  ///
+  /// In en, this message translates to:
+  /// **'Ride the wave'**
+  String get slogan;
+
+  /// No description provided for @lightsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Lights'**
+  String get lightsTitle;
+
+  /// Error when loading lights
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to load lights: {error}'**
+  String failedLoadLights(String error);
+
+  /// No description provided for @noCoords.
+  ///
+  /// In en, this message translates to:
+  /// **'no coords'**
+  String get noCoords;
+
+  /// Title with light id
+  ///
+  /// In en, this message translates to:
+  /// **'Light {id}'**
+  String lightWithId(int id);
+
+  /// No description provided for @settingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settingsTitle;
+
+  /// No description provided for @darkTheme.
+  ///
+  /// In en, this message translates to:
+  /// **'Dark theme'**
+  String get darkTheme;
+
+  /// No description provided for @english.
+  ///
+  /// In en, this message translates to:
+  /// **'English'**
+  String get english;
+
+  /// No description provided for @russian.
+  ///
+  /// In en, this message translates to:
+  /// **'Russian'**
+  String get russian;
+
+  /// No description provided for @language.
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get language;
+
+  /// No description provided for @supabaseUrl.
+  ///
+  /// In en, this message translates to:
+  /// **'Supabase URL'**
+  String get supabaseUrl;
+
+  /// No description provided for @supabaseKey.
+  ///
+  /// In en, this message translates to:
+  /// **'Supabase Key'**
+  String get supabaseKey;
+
+  /// Routing error message
+  ///
+  /// In en, this message translates to:
+  /// **'Route error: {error}'**
+  String routeError(String error);
+
+  /// No description provided for @lightAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Light added'**
+  String get lightAdded;
+
+  /// Error on adding item
+  ///
+  /// In en, this message translates to:
+  /// **'Add error: {error}'**
+  String addError(String error);
+
+  /// No description provided for @explorerTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Explorer'**
+  String get explorerTooltip;
+
+  /// No description provided for @refresh.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh'**
+  String get refresh;
+
+  /// No description provided for @profileCar.
+  ///
+  /// In en, this message translates to:
+  /// **'Car'**
+  String get profileCar;
+
+  /// No description provided for @profileFoot.
+  ///
+  /// In en, this message translates to:
+  /// **'Foot'**
+  String get profileFoot;
+
+  /// No description provided for @profileBike.
+  ///
+  /// In en, this message translates to:
+  /// **'Bike'**
+  String get profileBike;
+
+  /// Map tile loading error
+  ///
+  /// In en, this message translates to:
+  /// **'Tile load error: {error}'**
+  String tileLoadError(String error);
+
+  /// Single speed advice
+  ///
+  /// In en, this message translates to:
+  /// **'Go ~{speed} km/h'**
+  String speedAdvice(num speed);
+
+  /// No description provided for @notEnoughData.
+  ///
+  /// In en, this message translates to:
+  /// **'Not enough data. Ride with camera autolog.'**
+  String get notEnoughData;
+
+  /// No description provided for @noLightsOnRoute.
+  ///
+  /// In en, this message translates to:
+  /// **'No lights on route'**
+  String get noLightsOnRoute;
+
+  /// No description provided for @legendMinor.
+  ///
+  /// In en, this message translates to:
+  /// **'Minor'**
+  String get legendMinor;
+
+  /// No description provided for @legendMain.
+  ///
+  /// In en, this message translates to:
+  /// **'Main'**
+  String get legendMain;
+
+  /// No description provided for @legendPed.
+  ///
+  /// In en, this message translates to:
+  /// **'Pedestrians'**
+  String get legendPed;
+
+  /// No description provided for @clearRoute.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear route'**
+  String get clearRoute;
+
+  /// No description provided for @myLocation.
+  ///
+  /// In en, this message translates to:
+  /// **'My location'**
+  String get myLocation;
+
+  /// No description provided for @addLight.
+  ///
+  /// In en, this message translates to:
+  /// **'Add light'**
+  String get addLight;
+
+  /// No description provided for @cameraTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera — auto log'**
+  String get cameraTitle;
+
+  /// ROI hint text
+  ///
+  /// In en, this message translates to:
+  /// **'ROI: tap frame • Color: {color}'**
+  String roiInfo(String color);
+
+  /// No description provided for @noCameraPermission.
+  ///
+  /// In en, this message translates to:
+  /// **'No camera permission. Enable in settings.'**
+  String get noCameraPermission;
+
+  /// No description provided for @cameraNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera not found on device.'**
+  String get cameraNotFound;
+
+  /// Camera error message
+  ///
+  /// In en, this message translates to:
+  /// **'Camera error: {error}'**
+  String cameraError(String error);
+
+  /// No description provided for @adviceTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Speed advice'**
+  String get adviceTitle;
+
+  /// Cycle description with components
+  ///
+  /// In en, this message translates to:
+  /// **'Cycle {cycle}s (R {red} / Y {yellow} / G {green})'**
+  String cycleInfo(num cycle, num red, num yellow, num green);
+
+  /// Speed range to hold
+  ///
+  /// In en, this message translates to:
+  /// **'Keep ~{low}–{high} km/h'**
+  String holdSpeed(num low, num high);
+
+  /// No description provided for @unitsKmh.
+  ///
+  /// In en, this message translates to:
+  /// **'Units'**
+  String get unitsKmh;
+
+  /// No description provided for @roadSpeedLimit.
+  ///
+  /// In en, this message translates to:
+  /// **'Road speed limit (km/h)'**
+  String get roadSpeedLimit;
+
+  /// No description provided for @cameraOffset.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera clock offset (s)'**
+  String get cameraOffset;
+
+  /// No description provided for @jerkStep.
+  ///
+  /// In en, this message translates to:
+  /// **'Advisor jerk step'**
+  String get jerkStep;
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en', 'ru'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
+    case 'ru':
+      return AppLocalizationsRu();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
+}

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1,0 +1,207 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get appTitle => 'GreenWave';
+
+  @override
+  String get navMap => 'Map';
+
+  @override
+  String get navLights => 'Lights';
+
+  @override
+  String get navSettings => 'Settings';
+
+  @override
+  String get map => 'Map';
+
+  @override
+  String get lights => 'Lights';
+
+  @override
+  String get settings => 'Settings';
+
+  @override
+  String get signIn => 'Sign in';
+
+  @override
+  String get signUp => 'Sign up';
+
+  @override
+  String get createAccount => 'Create account';
+
+  @override
+  String get haveAccount => 'I have an account';
+
+  @override
+  String get email => 'Email';
+
+  @override
+  String get password => 'Password';
+
+  @override
+  String get emailLabel => 'Email';
+
+  @override
+  String get passwordLabel => 'Password';
+
+  @override
+  String get emailHint => 'Enter your email';
+
+  @override
+  String get passwordHint => 'Enter your password';
+
+  @override
+  String get slogan => 'Ride the wave';
+
+  @override
+  String get lightsTitle => 'Lights';
+
+  @override
+  String failedLoadLights(String error) {
+    return 'Failed to load lights: $error';
+  }
+
+  @override
+  String get noCoords => 'no coords';
+
+  @override
+  String lightWithId(int id) {
+    return 'Light $id';
+  }
+
+  @override
+  String get settingsTitle => 'Settings';
+
+  @override
+  String get darkTheme => 'Dark theme';
+
+  @override
+  String get english => 'English';
+
+  @override
+  String get russian => 'Russian';
+
+  @override
+  String get language => 'Language';
+
+  @override
+  String get supabaseUrl => 'Supabase URL';
+
+  @override
+  String get supabaseKey => 'Supabase Key';
+
+  @override
+  String routeError(String error) {
+    return 'Route error: $error';
+  }
+
+  @override
+  String get lightAdded => 'Light added';
+
+  @override
+  String addError(String error) {
+    return 'Add error: $error';
+  }
+
+  @override
+  String get explorerTooltip => 'Explorer';
+
+  @override
+  String get refresh => 'Refresh';
+
+  @override
+  String get profileCar => 'Car';
+
+  @override
+  String get profileFoot => 'Foot';
+
+  @override
+  String get profileBike => 'Bike';
+
+  @override
+  String tileLoadError(String error) {
+    return 'Tile load error: $error';
+  }
+
+  @override
+  String speedAdvice(num speed) {
+    return 'Go ~$speed km/h';
+  }
+
+  @override
+  String get notEnoughData => 'Not enough data. Ride with camera autolog.';
+
+  @override
+  String get noLightsOnRoute => 'No lights on route';
+
+  @override
+  String get legendMinor => 'Minor';
+
+  @override
+  String get legendMain => 'Main';
+
+  @override
+  String get legendPed => 'Pedestrians';
+
+  @override
+  String get clearRoute => 'Clear route';
+
+  @override
+  String get myLocation => 'My location';
+
+  @override
+  String get addLight => 'Add light';
+
+  @override
+  String get cameraTitle => 'Camera — auto log';
+
+  @override
+  String roiInfo(String color) {
+    return 'ROI: tap frame • Color: $color';
+  }
+
+  @override
+  String get noCameraPermission => 'No camera permission. Enable in settings.';
+
+  @override
+  String get cameraNotFound => 'Camera not found on device.';
+
+  @override
+  String cameraError(String error) {
+    return 'Camera error: $error';
+  }
+
+  @override
+  String get adviceTitle => 'Speed advice';
+
+  @override
+  String cycleInfo(num cycle, num red, num yellow, num green) {
+    return 'Cycle ${cycle}s (R $red / Y $yellow / G $green)';
+  }
+
+  @override
+  String holdSpeed(num low, num high) {
+    return 'Keep ~$low–$high km/h';
+  }
+
+  @override
+  String get unitsKmh => 'Units';
+
+  @override
+  String get roadSpeedLimit => 'Road speed limit (km/h)';
+
+  @override
+  String get cameraOffset => 'Camera clock offset (s)';
+
+  @override
+  String get jerkStep => 'Advisor jerk step';
+}

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1,0 +1,209 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Russian (`ru`).
+class AppLocalizationsRu extends AppLocalizations {
+  AppLocalizationsRu([String locale = 'ru']) : super(locale);
+
+  @override
+  String get appTitle => 'GreenWave';
+
+  @override
+  String get navMap => 'Карта';
+
+  @override
+  String get navLights => 'Светофоры';
+
+  @override
+  String get navSettings => 'Настройки';
+
+  @override
+  String get map => 'Карта';
+
+  @override
+  String get lights => 'Светофоры';
+
+  @override
+  String get settings => 'Настройки';
+
+  @override
+  String get signIn => 'Войти';
+
+  @override
+  String get signUp => 'Зарегистрироваться';
+
+  @override
+  String get createAccount => 'Создать аккаунт';
+
+  @override
+  String get haveAccount => 'У меня уже есть аккаунт';
+
+  @override
+  String get email => 'E‑mail';
+
+  @override
+  String get password => 'Пароль';
+
+  @override
+  String get emailLabel => 'E‑mail';
+
+  @override
+  String get passwordLabel => 'Пароль';
+
+  @override
+  String get emailHint => 'Введите e‑mail';
+
+  @override
+  String get passwordHint => 'Введите пароль';
+
+  @override
+  String get slogan => 'Лови волну зелёных';
+
+  @override
+  String get lightsTitle => 'Светофоры';
+
+  @override
+  String failedLoadLights(String error) {
+    return 'Не удалось загрузить светофоры: $error';
+  }
+
+  @override
+  String get noCoords => 'нет координат';
+
+  @override
+  String lightWithId(int id) {
+    return 'Светофор $id';
+  }
+
+  @override
+  String get settingsTitle => 'Настройки';
+
+  @override
+  String get darkTheme => 'Тёмная тема';
+
+  @override
+  String get english => 'Английский';
+
+  @override
+  String get russian => 'Русский';
+
+  @override
+  String get language => 'Язык';
+
+  @override
+  String get supabaseUrl => 'Supabase URL';
+
+  @override
+  String get supabaseKey => 'Supabase Key';
+
+  @override
+  String routeError(String error) {
+    return 'Ошибка маршрута: $error';
+  }
+
+  @override
+  String get lightAdded => 'Светофор добавлен';
+
+  @override
+  String addError(String error) {
+    return 'Ошибка добавления: $error';
+  }
+
+  @override
+  String get explorerTooltip => 'Обзор';
+
+  @override
+  String get refresh => 'Обновить';
+
+  @override
+  String get profileCar => 'Авто';
+
+  @override
+  String get profileFoot => 'Пешком';
+
+  @override
+  String get profileBike => 'Велосипед';
+
+  @override
+  String tileLoadError(String error) {
+    return 'Ошибка загрузки тайлов: $error';
+  }
+
+  @override
+  String speedAdvice(num speed) {
+    return 'Едьте ~$speed км/ч';
+  }
+
+  @override
+  String get notEnoughData =>
+      'Недостаточно данных. Проедьте с авто‑логом камеры.';
+
+  @override
+  String get noLightsOnRoute => 'На маршруте нет светофоров';
+
+  @override
+  String get legendMinor => 'Второстепенная';
+
+  @override
+  String get legendMain => 'Главная';
+
+  @override
+  String get legendPed => 'Пешеходы';
+
+  @override
+  String get clearRoute => 'Сбросить маршрут';
+
+  @override
+  String get myLocation => 'Моё местоположение';
+
+  @override
+  String get addLight => 'Добавить светофор';
+
+  @override
+  String get cameraTitle => 'Камера — авто‑лог';
+
+  @override
+  String roiInfo(String color) {
+    return 'ROI: тап по кадру • Цвет: $color';
+  }
+
+  @override
+  String get noCameraPermission =>
+      'Нет разрешения на камеру. Включите в настройках.';
+
+  @override
+  String get cameraNotFound => 'Камера не найдена на устройстве.';
+
+  @override
+  String cameraError(String error) {
+    return 'Ошибка камеры: $error';
+  }
+
+  @override
+  String get adviceTitle => 'Совет по скорости';
+
+  @override
+  String cycleInfo(num cycle, num red, num yellow, num green) {
+    return 'Цикл $cycleс (К $red / Ж $yellow / З $green)';
+  }
+
+  @override
+  String holdSpeed(num low, num high) {
+    return 'Держите ~$low–$high км/ч';
+  }
+
+  @override
+  String get unitsKmh => 'Единицы';
+
+  @override
+  String get roadSpeedLimit => 'Ограничение скорости (км/ч)';
+
+  @override
+  String get cameraOffset => 'Смещение часов камеры (с)';
+
+  @override
+  String get jerkStep => 'Шаг изменения совета';
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,7 @@
 // ignore: unused_import
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'env.dart';
@@ -13,15 +12,12 @@ import 'screens/map_screen.dart';
 import 'screens/lights_screen.dart';
 import 'screens/settings_screen.dart';
 
-final themeMode  = ValueNotifier<ThemeMode>(ThemeMode.system);
+final themeMode = ValueNotifier<ThemeMode>(ThemeMode.system);
 final themeColor = ValueNotifier<MaterialColor>(AppColors.themeColors.first);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Supabase.initialize(
-    url: Env.supabaseUrl,
-    anonKey: Env.supabaseAnonKey,
-  );
+  await Supabase.initialize(url: Env.supabaseUrl, anonKey: Env.supabaseAnonKey);
   runApp(const MyApp());
 }
 
@@ -44,9 +40,7 @@ class MyApp extends StatelessWidget {
               themeMode: mode,
               theme: AppTheme.light(color),
               darkTheme: AppTheme.dark(color),
-              routes: {
-                '/register': (_) => const RegisterPage(),
-              },
+              routes: {'/register': (_) => const RegisterPage()},
               home: const HomeTabs(),
             );
           },

--- a/lib/screens/advice_screen.dart
+++ b/lib/screens/advice_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../data/db.dart';
 import 'speed_advisor.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 
 class AdviceScreen extends StatefulWidget {
   final int lightId;
@@ -57,24 +57,29 @@ class _AdviceScreenState extends State<AdviceScreen> {
             : Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(l10n.cycleInfo(
+                  Text(
+                    l10n.cycleInfo(
                       _m!.tCycle.toStringAsFixed(1),
                       _m!.tRed.toStringAsFixed(1),
                       _m!.tYellow.toStringAsFixed(1),
-                      _m!.tGreen.toStringAsFixed(1))),
+                      _m!.tGreen.toStringAsFixed(1),
+                    ),
+                  ),
                   const SizedBox(height: 8),
                   if (_adv != null) ...[
                     Text(
                       _adv!.message,
-                      style: Theme.of(c)
-                          .textTheme
-                          .titleMedium
-                          ?.copyWith(fontWeight: FontWeight.bold),
+                      style: Theme.of(c).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                     if (_adv!.vLow != null && _adv!.vHigh != null)
-                      Text(l10n.holdSpeed(
+                      Text(
+                        l10n.holdSpeed(
                           (_adv!.vLow! * 3.6).toStringAsFixed(0),
-                          (_adv!.vHigh! * 3.6).toStringAsFixed(0))),
+                          (_adv!.vHigh! * 3.6).toStringAsFixed(0),
+                        ),
+                      ),
                   ],
                 ],
               ),

--- a/lib/screens/camera_screen.dart
+++ b/lib/screens/camera_screen.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:camera/camera.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 
 import '../data/db.dart';
 import '../data/models.dart';
@@ -81,10 +81,11 @@ class _CameraScreenState extends State<CameraScreen> {
       if (_stable != LightColor.unknown && _stable != _lastLogged) {
         final ps = Phase.values[_stable.index];
         final sample = PhaseSample(
-            lightId: widget.lightId,
-            phase: ps,
-            ts: DateTime.now(),
-            confidence: conf);
+          lightId: widget.lightId,
+          phase: ps,
+          ts: DateTime.now(),
+          confidence: conf,
+        );
         await _db.addSample(sample);
         try {
           SyncService.pushSamples([sample]); // fire-and-forget
@@ -131,9 +132,11 @@ class _CameraScreenState extends State<CameraScreen> {
       return Scaffold(
         appBar: AppBar(title: Text(l10n.cameraTitle)),
         body: Center(
-            child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text(_error!, textAlign: TextAlign.center))),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(_error!, textAlign: TextAlign.center),
+          ),
+        ),
       );
     }
 
@@ -146,23 +149,26 @@ class _CameraScreenState extends State<CameraScreen> {
       appBar: AppBar(title: Text(l10n.cameraTitle)),
       body: GestureDetector(
         onTapDown: (e) => _tapToSetRoi(e, context),
-        child: Stack(children: [
-          CameraPreview(_c!),
-          Positioned.fill(child: CustomPaint(painter: _RoiPainter(_roi))),
-          Positioned(
+        child: Stack(
+          children: [
+            CameraPreview(_c!),
+            Positioned.fill(child: CustomPaint(painter: _RoiPainter(_roi))),
+            Positioned(
               bottom: 16,
               left: 16,
               child: Container(
                 padding: const EdgeInsets.all(8),
                 color: AppColors.black54,
                 child: Text(
-                    l10n.roiInfo(_stable.toString()),
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyMedium
-                        ?.copyWith(color: AppColors.white)),
-              )),
-        ]),
+                  l10n.roiInfo(_stable.toString()),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(color: AppColors.white),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/lights_screen.dart
+++ b/lib/screens/lights_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 
 import '../main.dart';
 
@@ -20,9 +20,11 @@ class _LightsScreenState extends State<LightsScreen> {
           .from('lights')
           .select('id,name,lat,lon')
           .order('id');
-      setState(() => _items
-        ..clear()
-        ..addAll(List<Map<String, dynamic>>.from(res)));
+      setState(
+        () => _items
+          ..clear()
+          ..addAll(List<Map<String, dynamic>>.from(res)),
+      );
     } catch (e) {
       if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
@@ -51,11 +53,13 @@ class _LightsScreenState extends State<LightsScreen> {
             final l = _items[i];
             final lat = (l['lat'] as num?)?.toDouble();
             final lon = (l['lon'] as num?)?.toDouble();
-            final subtitle =
-                (lat != null && lon != null) ? '$lat, $lon' : l10n.noCoords;
+            final subtitle = (lat != null && lon != null)
+                ? '$lat, $lon'
+                : l10n.noCoords;
             return ListTile(
               title: Text(
-                  l['name'] as String? ?? l10n.lightWithId(l['id'].toString())),
+                l['name'] as String? ?? l10n.lightWithId(l['id'].toString()),
+              ),
               subtitle: Text(subtitle),
             );
           },

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../env.dart';
@@ -66,7 +66,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: Text(l10n.darkTheme),
             value: themeMode.value == ThemeMode.dark,
             onChanged: (v) => setState(
-                () => themeMode.value = v ? ThemeMode.dark : ThemeMode.light),
+              () => themeMode.value = v ? ThemeMode.dark : ThemeMode.light,
+            ),
           ),
           const SizedBox(height: 12),
           DropdownButtonFormField<String>(
@@ -121,7 +122,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     setState(() => themeColor.value = c);
                     final prefs = await SharedPreferences.getInstance();
                     await prefs.setInt(
-                        'primary_color', AppColors.themeColors.indexOf(c));
+                      'primary_color',
+                      AppColors.themeColors.indexOf(c),
+                    );
                   },
                   child: CircleAvatar(
                     backgroundColor: c,
@@ -152,7 +155,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             decoration: InputDecoration(labelText: l10n.supabaseKey),
             obscureText: true,
           ),
-      ],
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- remove synthetic l10n package configuration and write generated files to `lib/l10n/generated`
- reference localization code via `package:green_wave_app/l10n/generated/app_localizations.dart`
- add generated localization sources

## Testing
- `flutter gen-l10n`
- `flutter analyze lib/main.dart lib/features/auth/presentation/register_page.dart lib/screens/advice_screen.dart lib/screens/settings_screen.dart lib/screens/lights_screen.dart lib/screens/map_screen.dart lib/screens/camera_screen.dart` *(fails: 54 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9432ed348323b48ae79c6280294a