### PR TITLE
feat: load env vars at build time

### DIFF
--- a/.github/workflows/flutter-android-debug.yml
+++ b/.github/workflows/flutter-android-debug.yml
@@ -27,7 +27,10 @@ jobs:
         run: flutter pub get
 
       - name: Build debug APK
-        run: flutter build apk --debug
+        run: flutter build apk --debug \
+          --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_URL }} \
+          --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }} \
+          --dart-define=ORS_API_KEY=${{ secrets.ORS_API_KEY }}
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -14,4 +14,7 @@ jobs:
         with:
           channel: stable
       - run: flutter pub get
-      - run: flutter test
+      - run: flutter test \
+          --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_URL }} \
+          --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }} \
+          --dart-define=ORS_API_KEY=${{ secrets.ORS_API_KEY }}

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -44,5 +44,8 @@ jobs:
 
       # Сборка APK (debug). Если хочешь только проверки — временно закомментируй этот шаг.
       - name: Build debug APK
-        run: flutter build apk --debug
+        run: flutter build apk --debug \
+          --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_URL }} \
+          --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }} \
+          --dart-define=ORS_API_KEY=${{ secrets.ORS_API_KEY }}
         

--- a/README.md
+++ b/README.md
@@ -2,9 +2,25 @@
 
 A new Flutter project.
 
-## Getting Started
+## Environment variables
 
-This project is a starting point for a Flutter application.
+The application reads sensitive keys from compile-time environment variables.
+Provide these via `--dart-define` when running or building:
+
+```
+flutter run \
+  --dart-define=SUPABASE_URL=YOUR_URL \
+  --dart-define=SUPABASE_ANON_KEY=YOUR_ANON_KEY \
+  --dart-define=ORS_API_KEY=YOUR_ORS_KEY
+```
+
+Optional OAuth client IDs can also be supplied using
+`SUPABASE_GOOGLE_CLIENT_ID` and `SUPABASE_APPLE_CLIENT_ID`.
+
+In CI or deployment scripts, configure these values as environment secrets and
+pass them to `flutter build` with the same `--dart-define` flags.
+
+## Getting Started
 
 A few resources to get you started if this is your first Flutter project:
 

--- a/lib/env.dart
+++ b/lib/env.dart
@@ -1,16 +1,14 @@
- 
-
 /// Environment configuration for the application.
- 
+
 class Env {
-  /// Supabase project URL.
-  static const supabaseUrl = 'https://asoyjqtqtomxcdmsgehx.supabase.co';
+  /// Supabase project URL passed via `--dart-define` at build time.
+  static const supabaseUrl =
+      String.fromEnvironment('SUPABASE_URL', defaultValue: '');
 
-  /// Public anon key for the Supabase project.
+  /// Public anon key for the Supabase project, provided at build time.
   static const supabaseAnonKey =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFzb3lqcXRxdG9teGNkbXNnZWh4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMDc2NzIsImV4cCI6MjA3MDY4MzY3Mn0.AgVnUEmf4dO3aaVBJjZ1zJm0EFUQ0ghENtpkRqsXW4o';
+      String.fromEnvironment('SUPABASE_ANON_KEY', defaultValue: '');
 
- 
   /// Key used to persist the Supabase session locally.
   static const supabaseSessionKey = 'supabase_session';
 
@@ -19,10 +17,9 @@ class Env {
       String.fromEnvironment('SUPABASE_GOOGLE_CLIENT_ID', defaultValue: '');
   static const appleClientId =
       String.fromEnvironment('SUPABASE_APPLE_CLIENT_ID', defaultValue: '');
- 
 
   /// OpenRouteService API key used for routing requests.
   static const orsApiKey =
-      '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';
+      String.fromEnvironment('ORS_API_KEY', defaultValue: '');
 }
 

--- a/lib/shared/constants/app_strings.dart
+++ b/lib/shared/constants/app_strings.dart
@@ -2,10 +2,6 @@
 class AppStrings {
   AppStrings._();
 
-  static const String supabaseUrl = 'https://asoyjqtqtomxcdmsgehx.supabase.co';
-  static const String supabaseAnonKey =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFzb3lqcXRxdG9teGNkbXNnZWh4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMDc2NzIsImV4cCI6MjA3MDY4MzY3Mn0.AgVnUEmf4dO3aaVBJjZ1zJm0EFUQ0ghENtpkRqsXW4o';
-
   static const String profileCar = 'driving-car';
   static const String profileFoot = 'foot-walking';
   static const String profileBike = 'cycling-regular';
@@ -16,3 +12,4 @@ class AppStrings {
 
   static const String appTitle = 'GreenWave';
 }
+


### PR DESCRIPTION
## Summary
- replace hard-coded API keys with build-time environment lookups
- document new SUPABASE and ORS `--dart-define` variables
- pass secrets to Flutter builds in GitHub Actions

## Testing
- `flutter test` *(fails: command not found)*
- `dart format --output=none --set-exit-if-changed lib/env.dart lib/shared/constants/app_strings.dart README.md .github/workflows/flutter-android-debug.yml .github/workflows/flutter_ci.yml .github/workflows/flutter.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa99d731a4832393efc684823a4959