### PR TITLE
Fix conditional decoration on timer badge

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -433,25 +433,16 @@ class _TrafficLamp extends StatelessWidget {
           top: -6,
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
- 
             decoration: BoxDecoration(
               color: AppColors.white,
               borderRadius: BorderRadius.circular(10),
-              boxShadow: const [
-                BoxShadow(blurRadius: 4, color: AppColors.black26)
-              ],
+              boxShadow: disableAnimations
+                  ? null
+                  : const [
+                      BoxShadow(blurRadius: 4, color: AppColors.black26)
+                    ],
             ),
 
-              decoration: BoxDecoration(
-                color: AppColors.white,
-                borderRadius: BorderRadius.circular(10),
-                boxShadow: disableAnimations
-                    ? null
-                    : const [
-                        BoxShadow(blurRadius: 4, color: AppColors.black26)
-                      ],
-              ),
- 
             child: Text(
               '$leftSec',
               style: Theme.of(context)


### PR DESCRIPTION
## Summary
- remove duplicate `decoration` on timer badge container
- set `boxShadow` only when animations are enabled

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa5c0ede88323ae8ce8224e697b36