### PR TITLE
Use build-time environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Provide these via `--dart-define` when running or building:
 flutter run \
   --dart-define=SUPABASE_URL=YOUR_URL \
   --dart-define=SUPABASE_ANON_KEY=YOUR_ANON_KEY \
+  --dart-define=SUPABASE_SESSION_KEY=supabase_session \
   --dart-define=ORS_API_KEY=YOUR_ORS_KEY
 ```
 
 Optional OAuth client IDs can also be supplied using
 `SUPABASE_GOOGLE_CLIENT_ID` and `SUPABASE_APPLE_CLIENT_ID`.
+A custom storage key for the Supabase session can be provided with
+`SUPABASE_SESSION_KEY` (defaults to `supabase_session`).
 
 In CI or deployment scripts, configure these values as environment secrets and
 pass them to `flutter build` with the same `--dart-define` flags.

--- a/lib/env.dart
+++ b/lib/env.dart
@@ -9,8 +9,12 @@ class Env {
   static const supabaseAnonKey =
       String.fromEnvironment('SUPABASE_ANON_KEY', defaultValue: '');
 
-  /// Key used to persist the Supabase session locally.
-  static const supabaseSessionKey = 'supabase_session';
+  /// Key used to persist the Supabase session locally, provided at build time.
+  static const supabaseSessionKey =
+      String.fromEnvironment(
+    'SUPABASE_SESSION_KEY',
+    defaultValue: 'supabase_session',
+  );
 
   /// OAuth client IDs passed via `--dart-define` at build time.
   static const googleClientId =


### PR DESCRIPTION
## Summary
- load Supabase session key from compile-time environment variables
- document `SUPABASE_SESSION_KEY` in environment setup instructions

## Testing
- `dart format lib/env.dart` *(fails: command not found)*
- `flutter format lib/env.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa78295b88323b76f1026d6181deb