### PR TITLE
Handle Supabase errors in screens

### DIFF
--- a/lib/screens/cycles_screen.dart
+++ b/lib/screens/cycles_screen.dart
@@ -25,8 +25,16 @@ class _CyclesScreenState extends State<CyclesScreen>
   }
 
   Future<void> _loadLights() async {
-    final res = await _supa.from('lights').select('id,name').order('id');
-    setState(() => _lights = List<Map<String, dynamic>>.from(res));
+    try {
+      final res =
+          await _supa.from('lights').select('id,name').order('id');
+      if (!mounted) return;
+      setState(() => _lights = List<Map<String, dynamic>>.from(res));
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to load lights')));
+    }
   }
 
   Future<double> _avgDuration(String dir, String phase) async {


### PR DESCRIPTION
## Summary
- add try/catch around Supabase light queries in Speed Advisor and Cycles screens
- surface failures via SnackBars and update status accordingly

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa82f376483239632dceaa6db08ae