### PR TITLE
Fix map and lights screens and update Kotlin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()

--- a/lib/screens/lights_screen.dart
+++ b/lib/screens/lights_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:green_wave_app/l10n/generated/app_localizations.dart';
 
-import '../main.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+final supa = Supabase.instance.client;
 
 /// Simple list of traffic lights loaded from Supabase.
 class LightsScreen extends StatefulWidget {
@@ -58,7 +60,8 @@ class _LightsScreenState extends State<LightsScreen> {
                 : l10n.noCoords;
             return ListTile(
               title: Text(
-                l['name'] as String? ?? l10n.lightWithId(l['id'].toString()),
+                l['name'] as String?
+                    ?? l10n.lightWithId((l['id'] as num).toInt()),
               ),
               subtitle: Text(subtitle),
             );

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -283,8 +283,9 @@ class _MapScreenState extends State<MapScreen> {
               initialCenter: _defaultCenter,
               initialZoom: 15,
               onLongPress: (tap, latlng) => _setDest(latlng),
-              interactionOptions:
-                  InteractionOptions(flags: InteractiveFlag.all & ~InteractiveFlag.rotate),
+              interactionOptions: InteractionOptions(
+                flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+              ),
             ),
             children: [
               TileLayer(
@@ -307,9 +308,15 @@ class _MapScreenState extends State<MapScreen> {
                   headingDeg: _headingDeg ?? 0,
                 ),
               if (_route.isNotEmpty)
-                PolylineLayer(polylines: [
-                  Polyline(points: _route, strokeWidth: 4, color: AppColors.blue)
-                ]),
+                PolylineLayer(
+                  polylines: [
+                    Polyline(
+                      points: _route,
+                      strokeWidth: 4,
+                      color: AppColors.blue,
+                    )
+                  ],
+                ),
               Align(
                 alignment: Alignment.bottomCenter,
                 child: Container(
@@ -323,24 +330,31 @@ class _MapScreenState extends State<MapScreen> {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       if (_route.isNotEmpty)
-                    Text(_advised != null
-                        ? l10n.speedAdvice(_advised!.toString())
-                        : l10n.noLightsOnRoute),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      _LegendDot(color: AppColors.red, label: l10n.legendMinor),
-                      const SizedBox(width: 12),
-                      _LegendDot(color: AppColors.green, label: l10n.legendMain),
-                      const SizedBox(width: 12),
-                      _LegendDot(color: AppColors.blue, label: l10n.legendPed),
+                        Text(
+                          _advised != null
+                              ? l10n.speedAdvice(_advised!)
+                              : l10n.noLightsOnRoute,
+                        ),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _LegendDot(
+                              color: AppColors.red, label: l10n.legendMinor),
+                          const SizedBox(width: 12),
+                          _LegendDot(
+                              color: AppColors.green, label: l10n.legendMain),
+                          const SizedBox(width: 12),
+                          _LegendDot(
+                              color: AppColors.blue, label: l10n.legendPed),
+                        ],
+                      ),
                     ],
                   ),
-                ],
+                ),
               ),
-            ),
-          ),
-        ],
+            ],
+          );
+        },
       ),
       floatingActionButton: Column(
         mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- close `LayoutBuilder` and `Scaffold` in map screen and pass numeric speed to localization
- use Supabase instance client and correct `lightWithId` argument types
- bump Android Kotlin plugin to 2.1.0

## Testing
- `flutter clean` *(fails: command not found)*
- `dart format .` *(fails: command not found)*
- `flutter gen-l10n` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter build apk --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaad6736f4832391facd7c290b325d