### PR TITLE
feat: load supabase config from environment

### DIFF
--- a/lib/env.dart
+++ b/lib/env.dart
@@ -1,10 +1,19 @@
 /// Environment constants for Supabase and other services.
 
-/// Supabase project URL.
-const String supabaseUrl = "https://YOUR_PROJECT_ID.supabase.co";
+/// Supabase project URL provided via `--dart-define`.
+///
+/// Pass `--dart-define=SUPABASE_URL=your_url` when running or building the app.
+/// If not supplied, this defaults to an empty string which will cause network
+/// requests to fail.
+const String supabaseUrl =
+    String.fromEnvironment('SUPABASE_URL', defaultValue: '');
 
-/// Supabase anon public key.
-const String supabaseAnonKey = "YOUR_ANON_PUBLIC_KEY";
+/// Supabase anon public key supplied with `--dart-define`.
+///
+/// Use `--dart-define=SUPABASE_ANON_KEY=your_key` to provide the value. An empty
+/// default is used when no key is configured.
+const String supabaseAnonKey =
+    String.fromEnvironment('SUPABASE_ANON_KEY', defaultValue: '');
 
 /// OpenRouteService API key used for routing requests.
 const String orsApiKey = String.fromEnvironment('ORS_API_KEY', defaultValue: '');


### PR DESCRIPTION
## Summary
- read Supabase URL and anon key from compile-time environment variables instead of hard-coded placeholders

## Testing
- `dart format lib/env.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aabb44da148323b2988d33393c5621