### PR TITLE
fix: remove const TileLayer in MapPage

### DIFF
--- a/lib/ui/pages/map_page.dart
+++ b/lib/ui/pages/map_page.dart
@@ -83,7 +83,7 @@ class _MapPageState extends State<MapPage> {
               interactionOptions: const InteractionOptions(
                   flags: InteractiveFlag.all & ~InteractiveFlag.rotate),
             ),
-            children: const [
+            children: [
               TileLayer(
                 urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                 userAgentPackageName: 'com.example.green_wave_app',


### PR DESCRIPTION
## Summary
- fix FlutterMap initialization by removing `const` from `TileLayer`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aadd92f27483239d543be059ee0a94