### PR TITLE
chore: add react native scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ app.*.map.json
 # Игнорировать файлы с секретами
 .env
 .env.*
+
+# React Native
+apps/mobile/node_modules/
+apps/mobile/.expo/
+apps/mobile/dist/
+apps/mobile/.expo-shared/

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,0 +1,7 @@
+import { ExpoConfig } from 'expo/config';
+
+export default ({ config }: { config: ExpoConfig }) => ({
+  ...config,
+  name: 'green-wave-2',
+  slug: 'green-wave-2'
+});

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Green Wave 2.0</Text>
+    </View>
+  );
+}

--- a/apps/mobile/features/lights/api.ts
+++ b/apps/mobile/features/lights/api.ts
@@ -1,0 +1,30 @@
+import { supabase } from '../../lib/supabase';
+
+export async function listByBBox(
+  bbox: [number, number, number, number]
+) {
+  const [west, south, east, north] = bbox;
+  const { data, error } = await supabase
+    .from('lights')
+    .select('*')
+    .gte('lat', south)
+    .lte('lat', north)
+    .gte('lon', west)
+    .lte('lon', east);
+  if (error) throw error;
+  return data;
+}
+
+export async function createLight(
+  name: string,
+  lat: number,
+  lon: number
+) {
+  const { data, error } = await supabase
+    .from('lights')
+    .insert({ name, lat, lon })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}

--- a/apps/mobile/lib/supabase.ts
+++ b/apps/mobile/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.EXPO_PUBLIC_SUPABASE_URL!,
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!
+);

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "green-wave-2",
+  "version": "0.0.1",
+  "main": "app/index.tsx",
+  "scripts": {
+    "start": "expo start",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "expo": "^52.0.0",
+    "react": "^18.2.0",
+    "react-native": "^0.74.0",
+    "@supabase/supabase-js": "^2.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "moduleResolution": "node",
+    "strict": true,
+    "target": "esnext",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- add React Native Expo scaffold under `apps/mobile`
- set up Supabase client and lights API placeholder
- ignore Expo artifacts in git

## Testing
- `npm test --prefix apps/mobile`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1cf724948323a913b92e30b741c8