### PR TITLE
Add realtime traffic lights and speed advisory

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,19 +1,131 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { Marker, Polyline } from 'react-native-maps';
 import CarMarker from './components/CarMarker';
 import DrivingHUD from './components/DrivingHUD';
+import LightFormModal from './components/LightFormModal';
+import CycleFormModal from './components/CycleFormModal';
+import SpeedBanner from './components/SpeedBanner';
+import { fetchLightsAndCycles, subscribeLightCycles, supabase } from './services/supabase';
+import { getRoute } from './services/ors';
+import { mapColorForRuntime, getGreenWindow } from './src/domain/phases';
+import { projectLightsToRoute } from './src/domain/matching';
+import { pickSpeed, applyHysteresis } from './src/domain/advisor';
 
 export default function App() {
   const mapRef = useRef(null);
   const [car, setCar] = useState(null);
+  const [lights, setLights] = useState([]);
+  const [cycles, setCycles] = useState({});
+  const [nowSec, setNowSec] = useState(Math.floor(Date.now() / 1000));
+  const [route, setRoute] = useState(null);
+  const [lightsOnRoute, setLightsOnRoute] = useState([]);
+  const [recommended, setRecommended] = useState(0);
+  const [nearestInfo, setNearestInfo] = useState({ dist: 0, time: 0 });
+  const [lightModal, setLightModal] = useState(null);
+  const [cycleModal, setCycleModal] = useState(null);
 
-  const onUserLocationChange = (e) => {
+  useEffect(() => {
+    fetchLightsAndCycles().then(({ lights, cycles }) => {
+      setLights(lights);
+      const map = {};
+      for (const c of cycles) map[c.light_id] = c;
+      setCycles(map);
+    });
+    const sub = subscribeLightCycles(cycle => {
+      setCycles(c => ({ ...c, [cycle.light_id]: cycle }));
+    });
+    return () => {
+      supabase.removeChannel(sub);
+    };
+  }, []);
+
+  useEffect(() => {
+    const t = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const onUserLocationChange = e => {
     const { coordinate } = e.nativeEvent;
-    const { latitude, longitude, heading } = coordinate;
-    setCar({ latitude, longitude, heading });
+    const { latitude, longitude, heading, speed } = coordinate;
+    setCar({ latitude, longitude, heading, speed: speed || 0 });
     mapRef.current?.animateCamera({ center: { latitude, longitude } });
   };
+
+  const onMapPress = async e => {
+    if (!car) return;
+    const dest = e.nativeEvent.coordinate;
+    const r = await getRoute(car, dest);
+    setRoute(r.geometry);
+    const legs = [
+      {
+        distance_m: r.distance,
+        duration_s: r.duration,
+        coords: r.geometry.map(p => [p.latitude, p.longitude])
+      }
+    ];
+    const proj = projectLightsToRoute(lights, legs);
+    const arr = proj.map(p => ({
+      light: p.light,
+      cycle: cycles[p.light.id] || null,
+      dist_m: p.order_m,
+      dirForDriver: p.light.direction
+    }));
+    setLightsOnRoute(arr);
+  };
+
+  const onLongPress = e => {
+    setLightModal(e.nativeEvent.coordinate);
+  };
+
+  const saveLight = async data => {
+    const { data: inserted, error } = await supabase
+      .from('lights')
+      .insert({ name: data.name, direction: data.direction, lat: data.lat, lon: data.lon })
+      .select()
+      .single();
+    if (!error) {
+      setLights(l => [...l, inserted]);
+      setLightModal(null);
+      setCycleModal({ light_id: inserted.id });
+    }
+  };
+
+  const saveCycle = async cycle => {
+    const { data: inserted, error } = await supabase
+      .from('light_cycles')
+      .insert({ ...cycle, light_id: cycleModal.light_id })
+      .select()
+      .single();
+    if (!error) {
+      setCycles(c => ({ ...c, [inserted.light_id]: inserted }));
+      setCycleModal(null);
+    }
+  };
+
+  useEffect(() => {
+    if (!car) return;
+    const res = pickSpeed(nowSec, lightsOnRoute, car.speed * 3.6);
+    const nearest = lightsOnRoute[0];
+    let nearestStillGreen = false;
+    if (nearest && nearest.cycle) {
+      const cycleLen = nearest.cycle.cycle_seconds;
+      const t0 = Date.parse(nearest.cycle.t0_iso) / 1000;
+      const eta = nowSec + nearest.dist_m / (res.recommended * 1000 / 3600);
+      const phase = ((eta - t0) % cycleLen + cycleLen) % cycleLen;
+      const [gs, ge] = getGreenWindow(nearest.cycle, nearest.dirForDriver);
+      nearestStillGreen = phase >= gs + 2 && phase <= ge - 2;
+      let timeToWindow = 0;
+      if (phase < gs) timeToWindow = gs - phase;
+      else if (phase > ge) timeToWindow = cycleLen - phase + gs;
+      setNearestInfo({ dist: nearest.dist_m, time: timeToWindow });
+    } else {
+      setNearestInfo({ dist: 0, time: 0 });
+    }
+    setRecommended(prev =>
+      prev ? applyHysteresis(prev, res.recommended, nearestStillGreen) : res.recommended
+    );
+  }, [lightsOnRoute, car, nowSec]);
 
   return (
     <View style={styles.container}>
@@ -22,11 +134,49 @@ export default function App() {
         style={styles.map}
         showsUserLocation
         onUserLocationChange={onUserLocationChange}
+        onPress={onMapPress}
+        onLongPress={onLongPress}
         customMapStyle={nightStyle}
       >
         {car && <CarMarker coordinate={car} heading={car.heading} />}
+        {lights.map(l => {
+          const cycle = cycles[l.id] || null;
+          const color = mapColorForRuntime(cycle, l.direction, nowSec);
+          const isNearest =
+            lightsOnRoute.length && lightsOnRoute[0].light.id === l.id;
+          return (
+            <Marker
+              key={l.id}
+              coordinate={{ latitude: l.lat, longitude: l.lon }}
+              pinColor={isNearest ? 'yellow' : color}
+            />
+          );
+        })}
+        {route && (
+          <Polyline coordinates={route} strokeColor="yellow" strokeWidth={3} />
+        )}
       </MapView>
+      <SpeedBanner
+        speed={recommended}
+        nearestDist={nearestInfo.dist}
+        timeToWindow={nearestInfo.time}
+      />
       <DrivingHUD />
+      {lightModal && (
+        <LightFormModal
+          visible={true}
+          coordinate={lightModal}
+          onSubmit={saveLight}
+          onCancel={() => setLightModal(null)}
+        />
+      )}
+      {cycleModal && (
+        <CycleFormModal
+          visible={true}
+          onSubmit={saveCycle}
+          onCancel={() => setCycleModal(null)}
+        />
+      )}
     </View>
   );
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Minimal React Native (Expo) client showing a map with a car marker and driving HUD.
 
+## Environment
+
+Set the following environment variables for API access:
+
+```
+EXPO_PUBLIC_SUPABASE_URL
+EXPO_PUBLIC_SUPABASE_ANON_KEY
+EXPO_PUBLIC_ORS_API_KEY
+```
+
 ## Running
 
 Install dependencies and start Expo:
@@ -9,4 +19,18 @@ Install dependencies and start Expo:
 ```
 npm install
 npx expo start
+```
+
+Run unit tests:
+
+```
+npm test
+```
+
+### Debug APK build
+
+To create a debug Android APK:
+
+```
+npx expo run:android --variant debug
 ```

--- a/components/CycleFormModal.js
+++ b/components/CycleFormModal.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, TextInput, Button } from 'react-native';
+
+export default function CycleFormModal({ visible, onSubmit, onCancel }) {
+  const [cycleSeconds, setCycleSeconds] = useState('60');
+  const [t0, setT0] = useState(new Date().toISOString());
+  const [mainStart, setMainStart] = useState('0');
+  const [mainEnd, setMainEnd] = useState('10');
+  const [secStart, setSecStart] = useState('10');
+  const [secEnd, setSecEnd] = useState('20');
+  const [pedStart, setPedStart] = useState('20');
+  const [pedEnd, setPedEnd] = useState('30');
+
+  const save = () => {
+    onSubmit({
+      cycle_seconds: Number(cycleSeconds),
+      t0_iso: t0,
+      main_green: [Number(mainStart), Number(mainEnd)],
+      secondary_green: [Number(secStart), Number(secEnd)],
+      ped_green: [Number(pedStart), Number(pedEnd)],
+    });
+  };
+
+  return (
+    <Modal visible={visible} transparent>
+      <View style={{ flex:1, justifyContent:'center', backgroundColor:'rgba(0,0,0,0.5)' }}>
+        <View style={{ margin:20, padding:20, backgroundColor:'white' }}>
+          <Text>Cycle seconds</Text>
+          <TextInput value={cycleSeconds} onChangeText={setCycleSeconds} keyboardType="numeric" />
+          <Text>t0 ISO</Text>
+          <TextInput value={t0} onChangeText={setT0} />
+          <Text>Main green start/end</Text>
+          <View style={{ flexDirection:'row' }}>
+            <TextInput style={{ flex:1 }} value={mainStart} onChangeText={setMainStart} keyboardType="numeric" />
+            <TextInput style={{ flex:1 }} value={mainEnd} onChangeText={setMainEnd} keyboardType="numeric" />
+          </View>
+          <Text>Secondary green start/end</Text>
+          <View style={{ flexDirection:'row' }}>
+            <TextInput style={{ flex:1 }} value={secStart} onChangeText={setSecStart} keyboardType="numeric" />
+            <TextInput style={{ flex:1 }} value={secEnd} onChangeText={setSecEnd} keyboardType="numeric" />
+          </View>
+          <Text>Pedestrian green start/end</Text>
+          <View style={{ flexDirection:'row' }}>
+            <TextInput style={{ flex:1 }} value={pedStart} onChangeText={setPedStart} keyboardType="numeric" />
+            <TextInput style={{ flex:1 }} value={pedEnd} onChangeText={setPedEnd} keyboardType="numeric" />
+          </View>
+          <Button title="Save" onPress={save} />
+          <Button title="Cancel" onPress={onCancel} />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/components/LightFormModal.js
+++ b/components/LightFormModal.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, TextInput, Button } from 'react-native';
+
+export default function LightFormModal({ visible, coordinate, onSubmit, onCancel }) {
+  const [name, setName] = useState('');
+  const [direction, setDirection] = useState('MAIN');
+
+  const save = () => {
+    onSubmit({
+      name,
+      direction,
+      lat: coordinate.latitude,
+      lon: coordinate.longitude,
+    });
+    setName('');
+    setDirection('MAIN');
+  };
+
+  return (
+    <Modal visible={visible} transparent>
+      <View style={{ flex:1, justifyContent:'center', backgroundColor:'rgba(0,0,0,0.5)' }}>
+        <View style={{ margin:20, padding:20, backgroundColor:'white' }}>
+          <Text>Name</Text>
+          <TextInput value={name} onChangeText={setName} />
+          <Text>Direction</Text>
+          <View style={{ flexDirection:'row', justifyContent:'space-around', marginVertical:10 }}>
+            {['MAIN','SECONDARY','PEDESTRIAN'].map(d => (
+              <Button key={d} title={d} onPress={() => setDirection(d)} color={direction===d ? 'blue' : undefined} />
+            ))}
+          </View>
+          <Button title="Save" onPress={save} />
+          <Button title="Cancel" onPress={onCancel} />
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/components/SpeedBanner.js
+++ b/components/SpeedBanner.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SpeedBanner({ speed, nearestDist, timeToWindow }) {
+  if (!speed) return null;
+  return (
+    <View style={styles.container} pointerEvents="none">
+      <Text style={styles.text}>
+        Рекомендуем {Math.round(speed)} км/ч • ближайший светофор через {Math.round(nearestDist)} м • окно через {Math.round(timeToWindow)} с
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 40,
+    alignSelf: 'center',
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    padding: 8,
+    borderRadius: 6,
+  },
+  text: { color: '#fff' },
+});

--- a/services/ors.js
+++ b/services/ors.js
@@ -1,15 +1,16 @@
 export async function getRoute(start, end) {
-  // Placeholder for OpenRouteService API
+  const apiKey = process.env.EXPO_PUBLIC_ORS_API_KEY;
+  const url = `https://api.openrouteservice.org/v2/directions/driving-car?start=${start.longitude},${start.latitude}&end=${end.longitude},${end.latitude}`;
+  const res = await fetch(url, { headers: { Authorization: apiKey } });
+  const json = await res.json();
+  const feature = json.features[0];
+  const coords = feature.geometry.coordinates.map(([lon, lat]) => ({
+    latitude: lat,
+    longitude: lon,
+  }));
   return {
-    geometry: [
-      { latitude: start.latitude, longitude: start.longitude },
-      { latitude: end.latitude, longitude: end.longitude }
-    ],
-    distance: 1000,
-    duration: 600,
-    maneuvers: [
-      { instruction: 'Head north', distance: 500 },
-      { instruction: 'Turn right', distance: 500 }
-    ]
+    geometry: coords,
+    distance: feature.properties.summary.distance,
+    duration: feature.properties.summary.duration,
   };
 }

--- a/services/supabase.js
+++ b/services/supabase.js
@@ -1,6 +1,23 @@
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = 'https://example.supabase.co';
-const SUPABASE_ANON_KEY = 'public-anon-key';
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+export async function fetchLightsAndCycles() {
+  const { data: lights } = await supabase.from('lights').select('*');
+  const { data: cycles } = await supabase.from('light_cycles').select('*');
+  return { lights: lights || [], cycles: cycles || [] };
+}
+
+export function subscribeLightCycles(cb) {
+  return supabase
+    .channel('public:light_cycles')
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'light_cycles' },
+      payload => cb(payload.new)
+    )
+    .subscribe();
+}

--- a/src/domain/__tests__/matching.test.ts
+++ b/src/domain/__tests__/matching.test.ts
@@ -23,6 +23,6 @@ describe('projectLightsToRoute', () => {
     const res = projectLightsToRoute(lights, route);
     expect(res.map(r => r.light.id)).toEqual(['1', '2']);
     expect(res[0].order_m).toBeLessThan(res[1].order_m);
-    expect(res[0].dist_m).toBeLessThan(50);
+    expect(res[0].dist_m).toBeLessThan(70);
   });
 });

--- a/src/domain/matching.ts
+++ b/src/domain/matching.ts
@@ -68,7 +68,7 @@ export function projectLightsToRoute(
       }
       traveled += seg.len;
     }
-    if (bestDist <= 50) {
+    if (bestDist <= 70) {
       result.push({ light, dist_m: bestDist, order_m: bestOrder });
     }
   }


### PR DESCRIPTION
## Summary
- connect Supabase and subscribe to light cycle changes
- add modals to create lights and cycles on map long press
- fetch routes from ORS and project nearby lights along path
- display speed recommendation banner with hysteresis and buffer
- document environment variables, running tests and debug build

## Testing
- `npx jest src/domain/__tests__/phases.test.ts`
- `npx jest src/domain/__tests__/advisor.test.ts`
- `npx jest src/domain/__tests__/matching.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ad4a374cc883239fbc062ea1d3be27