### PR TITLE
Improve OpenRouteService error handling

### DIFF
--- a/src/ors.test.ts
+++ b/src/ors.test.ts
@@ -1,0 +1,36 @@
+const { getRoute } = require('../services/ors');
+
+const start = { latitude: 1, longitude: 2 };
+const end = { latitude: 3, longitude: 4 };
+
+describe('getRoute', () => {
+  beforeEach(() => {
+    process.env.EXPO_PUBLIC_ORS_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.EXPO_PUBLIC_ORS_API_KEY;
+  });
+
+  it('throws when API key is missing', async () => {
+    delete process.env.EXPO_PUBLIC_ORS_API_KEY;
+    const fetchSpy = jest.spyOn(global, 'fetch');
+    await expect(getRoute(start, end)).rejects.toThrow('EXPO_PUBLIC_ORS_API_KEY is required');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws on non-ok responses', async () => {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: jest.fn().mockResolvedValue('server error'),
+      } as any);
+
+    await expect(getRoute(start, end)).rejects.toThrow('OpenRouteService error 500: server error');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle missing `EXPO_PUBLIC_ORS_API_KEY`
- add fetch error and `res.ok` checks in ORS service
- add tests covering missing key and failed responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad588826f8832380b883c970c7695e