### PR TITLE
Add validation for light and cycle modals

### DIFF
--- a/components/CycleFormModal.js
+++ b/components/CycleFormModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Modal, View, Text, TextInput, Button } from 'react-native';
+import { Modal, View, Text, TextInput, Button, Alert } from 'react-native';
+import { validateCycle } from '../src/validation';
 
 export default function CycleFormModal({ visible, onSubmit, onCancel }) {
   const [cycleSeconds, setCycleSeconds] = useState('60');
@@ -10,8 +11,30 @@ export default function CycleFormModal({ visible, onSubmit, onCancel }) {
   const [secEnd, setSecEnd] = useState('20');
   const [pedStart, setPedStart] = useState('20');
   const [pedEnd, setPedEnd] = useState('30');
+  const error = validateCycle({
+    cycleSeconds,
+    mainStart,
+    mainEnd,
+    secStart,
+    secEnd,
+    pedStart,
+    pedEnd,
+  });
 
   const save = () => {
+    const msg = validateCycle({
+      cycleSeconds,
+      mainStart,
+      mainEnd,
+      secStart,
+      secEnd,
+      pedStart,
+      pedEnd,
+    });
+    if (msg) {
+      Alert.alert('Validation', msg);
+      return;
+    }
     onSubmit({
       cycle_seconds: Number(cycleSeconds),
       t0_iso: t0,
@@ -44,7 +67,7 @@ export default function CycleFormModal({ visible, onSubmit, onCancel }) {
             <TextInput style={{ flex:1 }} value={pedStart} onChangeText={setPedStart} keyboardType="numeric" />
             <TextInput style={{ flex:1 }} value={pedEnd} onChangeText={setPedEnd} keyboardType="numeric" />
           </View>
-          <Button title="Save" onPress={save} />
+          <Button title="Save" onPress={save} disabled={!!error} />
           <Button title="Cancel" onPress={onCancel} />
         </View>
       </View>

--- a/components/LightFormModal.js
+++ b/components/LightFormModal.js
@@ -1,11 +1,18 @@
 import React, { useState } from 'react';
-import { Modal, View, Text, TextInput, Button } from 'react-native';
+import { Modal, View, Text, TextInput, Button, Alert } from 'react-native';
+import { validateLight } from '../src/validation';
 
 export default function LightFormModal({ visible, coordinate, onSubmit, onCancel }) {
   const [name, setName] = useState('');
   const [direction, setDirection] = useState('MAIN');
+  const error = validateLight(name, direction);
 
   const save = () => {
+    const msg = validateLight(name, direction);
+    if (msg) {
+      Alert.alert('Validation', msg);
+      return;
+    }
     onSubmit({
       name,
       direction,
@@ -28,7 +35,7 @@ export default function LightFormModal({ visible, coordinate, onSubmit, onCancel
               <Button key={d} title={d} onPress={() => setDirection(d)} color={direction===d ? 'blue' : undefined} />
             ))}
           </View>
-          <Button title="Save" onPress={save} />
+          <Button title="Save" onPress={save} disabled={!!error} />
           <Button title="Cancel" onPress={onCancel} />
         </View>
       </View>

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -1,0 +1,55 @@
+import { validateLight, validateCycle } from '../validation';
+
+describe('validateLight', () => {
+  test('requires name', () => {
+    expect(validateLight('', 'MAIN')).toBe('Name is required');
+  });
+
+  test('requires valid direction', () => {
+    expect(validateLight('name', 'WRONG')).toBe('Direction is invalid');
+  });
+
+  test('passes for valid data', () => {
+    expect(validateLight('name', 'MAIN')).toBeNull();
+  });
+});
+
+describe('validateCycle', () => {
+  const base = {
+    cycleSeconds: '60',
+    mainStart: '0',
+    mainEnd: '10',
+    secStart: '10',
+    secEnd: '20',
+    pedStart: '20',
+    pedEnd: '30',
+  };
+
+  test('numbers required', () => {
+    expect(
+      validateCycle({ ...base, cycleSeconds: 'abc' })
+    ).toBe('All numeric fields must be valid numbers');
+  });
+
+  test('main start must be less than end', () => {
+    expect(
+      validateCycle({ ...base, mainStart: '5', mainEnd: '5' })
+    ).toBe('Main start must be less than end');
+  });
+
+  test('secondary start must be less than end', () => {
+    expect(
+      validateCycle({ ...base, secStart: '15', secEnd: '15' })
+    ).toBe('Secondary start must be less than end');
+  });
+
+  test('pedestrian start must be less than end', () => {
+    expect(
+      validateCycle({ ...base, pedStart: '25', pedEnd: '25' })
+    ).toBe('Pedestrian start must be less than end');
+  });
+
+  test('passes for valid data', () => {
+    expect(validateCycle(base)).toBeNull();
+  });
+});

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,45 @@
+export const validateLight = (name: string, direction: string): string | null => {
+  if (!name.trim()) {
+    return 'Name is required';
+  }
+  const allowed = ['MAIN', 'SECONDARY', 'PEDESTRIAN'];
+  if (!allowed.includes(direction)) {
+    return 'Direction is invalid';
+  }
+  return null;
+};
+
+export interface CycleFields {
+  cycleSeconds: string;
+  mainStart: string;
+  mainEnd: string;
+  secStart: string;
+  secEnd: string;
+  pedStart: string;
+  pedEnd: string;
+}
+
+export const validateCycle = ({
+  cycleSeconds,
+  mainStart,
+  mainEnd,
+  secStart,
+  secEnd,
+  pedStart,
+  pedEnd,
+}: CycleFields): string | null => {
+  const values = [cycleSeconds, mainStart, mainEnd, secStart, secEnd, pedStart, pedEnd].map(Number);
+  if (values.some(v => Number.isNaN(v))) {
+    return 'All numeric fields must be valid numbers';
+  }
+  if (Number(mainStart) >= Number(mainEnd)) {
+    return 'Main start must be less than end';
+  }
+  if (Number(secStart) >= Number(secEnd)) {
+    return 'Secondary start must be less than end';
+  }
+  if (Number(pedStart) >= Number(pedEnd)) {
+    return 'Pedestrian start must be less than end';
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- validate light form name and direction with disabled save and alerts
- validate cycle form numeric fields and window order
- add shared validators and unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad66ac1c288323884f84e7e3511a7f