### PR TITLE
Handle Supabase errors and surface load failures

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Text } from 'react-native';
 import MapView, { Marker, Polyline } from 'react-native-maps';
 import CarMarker from './components/CarMarker';
 import DrivingHUD from './components/DrivingHUD';
@@ -24,9 +24,14 @@ export default function App() {
   const [nearestInfo, setNearestInfo] = useState({ dist: 0, time: 0 });
   const [lightModal, setLightModal] = useState(null);
   const [cycleModal, setCycleModal] = useState(null);
+  const [loadError, setLoadError] = useState(null);
 
   useEffect(() => {
-    fetchLightsAndCycles().then(({ lights, cycles }) => {
+    fetchLightsAndCycles().then(({ lights, cycles, error }) => {
+      if (error) {
+        setLoadError('Failed to load data');
+        return;
+      }
       setLights(lights);
       const map = {};
       for (const c of cycles) map[c.light_id] = c;
@@ -129,6 +134,7 @@ export default function App() {
 
   return (
     <View style={styles.container}>
+      {loadError && <Text testID="load-error">{loadError}</Text>}
       <MapView
         ref={mapRef}
         style={styles.map}

--- a/src/supabase.test.ts
+++ b/src/supabase.test.ts
@@ -1,0 +1,51 @@
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: jest.fn(),
+    channel: jest.fn(() => ({ on: jest.fn().mockReturnThis(), subscribe: jest.fn() })),
+    removeChannel: jest.fn(),
+  })),
+}));
+
+describe('fetchLightsAndCycles error handling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns error when fetching lights fails', async () => {
+    const { fetchLightsAndCycles, supabase } = require('../services/supabase');
+    const originalFrom = supabase.from;
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    supabase.from = jest.fn().mockReturnValue({
+      select: jest.fn().mockResolvedValue({ data: null, error: new Error('lights') }),
+    });
+
+    const res = await fetchLightsAndCycles();
+    expect(res.error).toBeTruthy();
+    expect(consoleSpy).toHaveBeenCalledWith('Error fetching lights:', expect.any(Error));
+
+    supabase.from = originalFrom;
+  });
+
+  it('returns error when fetching cycles fails', async () => {
+    const { fetchLightsAndCycles, supabase } = require('../services/supabase');
+    const originalFrom = supabase.from;
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    supabase.from = jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        select: jest.fn().mockResolvedValue({ data: [], error: null }),
+      }))
+      .mockImplementationOnce(() => ({
+        select: jest.fn().mockResolvedValue({ data: null, error: new Error('cycles') }),
+      }));
+
+    const res = await fetchLightsAndCycles();
+    expect(res.error).toBeTruthy();
+    expect(consoleSpy).toHaveBeenCalledWith('Error fetching cycles:', expect.any(Error));
+
+    supabase.from = originalFrom;
+  });
+});
+


### PR DESCRIPTION
## Summary
- check Supabase response for each query and return/log errors
- surface data load failures in App with a simple message
- test error paths for Supabase queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6061e8c08323bd87dcdf8b6d780c