### PR TITLE
feat: add i18n support

### DIFF
--- a/components/SpeedBanner.js
+++ b/components/SpeedBanner.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import i18n from '../src/i18n';
 
 export default function SpeedBanner({ speed, nearestDist, timeToWindow }) {
   if (!speed) return null;
   return (
     <View style={styles.container} pointerEvents="none">
       <Text style={styles.text}>
-        Рекомендуем {Math.round(speed)} км/ч • ближайший светофор через {Math.round(nearestDist)} м • окно через {Math.round(timeToWindow)} с
+        {i18n.t('speedBanner.recommendation', {
+          speed: Math.round(speed),
+          distance: Math.round(nearestDist),
+          time: Math.round(timeToWindow),
+        })}
       </Text>
     </View>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.56.0",
         "expo": "^53.0.0",
+        "expo-localization": "^16.1.6",
         "expo-location": "^18.0.0",
+        "i18n-js": "^4.5.1",
         "metro": "^0.82.0",
         "react": "18.2.0",
         "react-native": "0.74.5",
@@ -5629,6 +5631,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -6935,6 +6946,19 @@
         "react": "*"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-16.1.6.tgz",
+      "integrity": "sha512-v4HwNzs8QvyKHwl40MvETNEKr77v1o9/eVC8WCBY++DIlBAvonHyJe2R9CfqpZbC4Tlpl7XV+07nLXc8O5PQsA==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-location": {
       "version": "18.1.6",
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.1.6.tgz",
@@ -7433,6 +7457,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18n-js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/i18n-js/-/i18n-js-4.5.1.tgz",
+      "integrity": "sha512-n7jojFj1WC0tztgr0I8jqTXuIlY1xNzXnC3mjKX/YjJhimdM+jXM8vOmn9d3xQFNC6qDHJ4ovhdrGXrRXLIGkA==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "*",
+        "lodash": "*",
+        "make-plural": "*"
       }
     },
     "node_modules/ieee754": {
@@ -9086,6 +9121,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9419,6 +9460,12 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/make-plural": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.4.0.tgz",
+      "integrity": "sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg==",
+      "license": "Unicode-DFS-2016"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -11946,6 +11993,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.56.0",
     "expo": "^53.0.0",
+    "expo-localization": "^16.1.6",
     "expo-location": "^18.0.0",
+    "i18n-js": "^4.5.1",
     "metro": "^0.82.0",
     "react": "18.2.0",
     "react-native": "0.74.5",

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,0 +1,33 @@
+jest.mock(
+  'expo-localization',
+  () => ({ getLocales: () => [{ languageTag: 'en-US' }] }),
+  { virtual: true }
+);
+
+import i18n from './i18n';
+
+describe('i18n translations', () => {
+  it('renders Russian recommendation', () => {
+    i18n.locale = 'ru';
+    const res = i18n.t('speedBanner.recommendation', {
+      speed: 40,
+      distance: 100,
+      time: 20,
+    });
+    expect(res).toBe(
+      'Рекомендуем 40 км/ч • ближайший светофор через 100 м • окно через 20 с'
+    );
+  });
+
+  it('renders English recommendation', () => {
+    i18n.locale = 'en';
+    const res = i18n.t('speedBanner.recommendation', {
+      speed: 40,
+      distance: 100,
+      time: 20,
+    });
+    expect(res).toBe(
+      'Recommend 40 km/h • next light in 100 m • window in 20 s'
+    );
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,25 @@
+import { I18n } from 'i18n-js';
+import * as Localization from 'expo-localization';
+
+const translations = {
+  en: {
+    speedBanner: {
+      recommendation: 'Recommend %{speed} km/h • next light in %{distance} m • window in %{time} s',
+    },
+  },
+  ru: {
+    speedBanner: {
+      recommendation: 'Рекомендуем %{speed} км/ч • ближайший светофор через %{distance} м • окно через %{time} с',
+    },
+  },
+};
+
+const i18n = new I18n(translations);
+i18n.enableFallback = true;
+
+const locales = Localization.getLocales();
+if (locales.length > 0) {
+  i18n.locale = locales[0].languageTag.split('-')[0];
+}
+
+export default i18n;


### PR DESCRIPTION
## Summary
- integrate i18n-js with Expo localization
- move SpeedBanner text into translation files
- test translations for Russian and English

## Testing
- `npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68ad6cb049e88323a6710cb96746fca8