### PR TITLE
feat: add main menu with localized options

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,11 +1,12 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
 import MapView, { Marker, Polyline } from 'react-native-maps';
 import CarMarker from './components/CarMarker';
 import DrivingHUD from './components/DrivingHUD';
 import LightFormModal from './components/LightFormModal';
 import CycleFormModal from './components/CycleFormModal';
 import SpeedBanner from './components/SpeedBanner';
+import MainMenu from './components/MainMenu';
 import { fetchLightsAndCycles, subscribeLightCycles, supabase } from './services/supabase';
 import { getRoute } from './services/ors';
 import { mapColorForRuntime, getGreenWindow } from './src/domain/phases';
@@ -33,6 +34,36 @@ export default function App() {
     speedLimit: 0,
   });
   const [steps, setSteps] = useState([]);
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const handleStartNavigation = () => {
+    setMenuVisible(false);
+  };
+
+  const handleCancelRoute = () => {
+    setRoute(null);
+    setSteps([]);
+    setHudInfo({
+      maneuver: '',
+      distance: 0,
+      street: '',
+      eta: 0,
+      speedLimit: 0,
+    });
+    setLightsOnRoute([]);
+    setRecommended(0);
+    setNearestInfo({ dist: 0, time: 0 });
+    setMenuVisible(false);
+  };
+
+  const handleAddLight = () => {
+    if (car) setLightModal({ latitude: car.latitude, longitude: car.longitude });
+    setMenuVisible(false);
+  };
+
+  const handleSettings = () => {
+    setMenuVisible(false);
+  };
 
   useEffect(() => {
     fetchLightsAndCycles().then(({ lights, cycles, error }) => {
@@ -194,6 +225,20 @@ export default function App() {
         speed={car ? car.speed * 3.6 : 0}
         speedLimit={hudInfo.speedLimit}
       />
+      <MainMenu
+        visible={menuVisible}
+        onStartNavigation={handleStartNavigation}
+        onCancelRoute={handleCancelRoute}
+        onAddLight={handleAddLight}
+        onSettings={handleSettings}
+      />
+      <TouchableOpacity
+        style={styles.fab}
+        onPress={() => setMenuVisible(v => !v)}
+        testID="menu-button"
+      >
+        <Text style={styles.fabText}>☰</Text>
+      </TouchableOpacity>
       {lightModal && (
         <LightFormModal
           visible={true}
@@ -232,5 +277,20 @@ const nightStyle = [
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  map: { flex: 1 }
+  map: { flex: 1 },
+  fab: {
+    position: 'absolute',
+    bottom: 20,
+    right: 20,
+    width: 50,
+    height: 50,
+    backgroundColor: 'rgba(0,0,0,0.8)',
+    borderRadius: 25,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fabText: {
+    color: '#fff',
+    fontSize: 24,
+  }
 });

--- a/components/MainMenu.js
+++ b/components/MainMenu.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import i18n from '../src/i18n';
+
+export default function MainMenu({
+  visible,
+  onStartNavigation,
+  onCancelRoute,
+  onAddLight,
+  onSettings,
+}) {
+  if (!visible) return null;
+  return (
+    <View style={styles.container} testID="main-menu">
+      <TouchableOpacity onPress={onStartNavigation} style={styles.item}>
+        <Text style={styles.text}>{i18n.t('menu.startNavigation')}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onCancelRoute} style={styles.item}>
+        <Text style={styles.text}>{i18n.t('menu.cancelRoute')}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onAddLight} style={styles.item}>
+        <Text style={styles.text}>{i18n.t('menu.addLight')}</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={onSettings} style={styles.item}>
+        <Text style={styles.text}>{i18n.t('menu.settings')}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 80,
+    right: 20,
+    backgroundColor: 'rgba(0,0,0,0.8)',
+    padding: 8,
+    borderRadius: 6,
+  },
+  item: {
+    paddingVertical: 4,
+  },
+  text: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});
+

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,10 +6,22 @@ const translations = {
     speedBanner: {
       recommendation: 'Recommend %{speed} km/h • next light in %{distance} m • window in %{time} s',
     },
+    menu: {
+      startNavigation: 'Start Navigation',
+      cancelRoute: 'Cancel Route',
+      addLight: 'Add Light',
+      settings: 'Settings',
+    },
   },
   ru: {
     speedBanner: {
       recommendation: 'Рекомендуем %{speed} км/ч • ближайший светофор через %{distance} м • окно через %{time} с',
+    },
+    menu: {
+      startNavigation: 'Начать навигацию',
+      cancelRoute: 'Отменить маршрут',
+      addLight: 'Добавить светофор',
+      settings: 'Настройки',
     },
   },
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,2 @@
+declare module 'expo-localization';
+declare module 'i18n-js';


### PR DESCRIPTION
## Summary
- add floating menu button and main menu component for navigation actions
- localize menu strings in i18n
- wire callbacks to cancel routes and add lights

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad771a25ac8323ae7b055a7f625a80