### PR TITLE
Add Clear Route option and reset navigation state

### DIFF
--- a/App.js
+++ b/App.js
@@ -40,7 +40,7 @@ export default function App() {
     setMenuVisible(false);
   };
 
-  const handleCancelRoute = () => {
+  const handleClearRoute = () => {
     setRoute(null);
     setSteps([]);
     setHudInfo({
@@ -228,7 +228,7 @@ export default function App() {
       <MainMenu
         visible={menuVisible}
         onStartNavigation={handleStartNavigation}
-        onCancelRoute={handleCancelRoute}
+        onClearRoute={handleClearRoute}
         onAddLight={handleAddLight}
         onSettings={handleSettings}
       />

--- a/components/DrivingHUD.js
+++ b/components/DrivingHUD.js
@@ -26,7 +26,9 @@ export default function DrivingHUD({
         <Text testID="hud-street" style={styles.text}>{street}</Text>
       </View>
       <View style={styles.etaPanel}>
-        <Text testID="hud-eta" style={styles.text}>ETA: {Math.round(eta)}s</Text>
+        <Text testID="hud-eta" style={styles.text}>
+          ETA: {eta ? Math.round(eta) : '--'}s
+        </Text>
       </View>
     </SafeAreaView>
   );

--- a/components/MainMenu.js
+++ b/components/MainMenu.js
@@ -5,7 +5,7 @@ import i18n from '../src/i18n';
 export default function MainMenu({
   visible,
   onStartNavigation,
-  onCancelRoute,
+  onClearRoute,
   onAddLight,
   onSettings,
 }) {
@@ -15,8 +15,8 @@ export default function MainMenu({
       <TouchableOpacity onPress={onStartNavigation} style={styles.item}>
         <Text style={styles.text}>{i18n.t('menu.startNavigation')}</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={onCancelRoute} style={styles.item}>
-        <Text style={styles.text}>{i18n.t('menu.cancelRoute')}</Text>
+      <TouchableOpacity onPress={onClearRoute} style={styles.item}>
+        <Text style={styles.text}>{i18n.t('menu.clearRoute')}</Text>
       </TouchableOpacity>
       <TouchableOpacity onPress={onAddLight} style={styles.item}>
         <Text style={styles.text}>{i18n.t('menu.addLight')}</Text>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -8,7 +8,7 @@ const translations = {
     },
     menu: {
       startNavigation: 'Start Navigation',
-      cancelRoute: 'Cancel Route',
+      clearRoute: 'Clear Route',
       addLight: 'Add Light',
       settings: 'Settings',
     },
@@ -19,7 +19,7 @@ const translations = {
     },
     menu: {
       startNavigation: 'Начать навигацию',
-      cancelRoute: 'Отменить маршрут',
+      clearRoute: 'Очистить маршрут',
       addLight: 'Добавить светофор',
       settings: 'Настройки',
     },


### PR DESCRIPTION
## Summary
- add Clear Route action in main menu
- reset navigation state when clearing route
- handle no route in DrivingHUD ETA panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7d34d3d083238e9630b72bd43742