### PR TITLE
Add localization for forms, validation, and HUD

### DIFF
--- a/__mocks__/expo-localization.js
+++ b/__mocks__/expo-localization.js
@@ -1,0 +1,4 @@
+module.exports = {
+  getLocales: () => [{ languageTag: 'en-US' }],
+};
+

--- a/components/CycleFormModal.js
+++ b/components/CycleFormModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Modal, View, Text, TextInput, Button, Alert } from 'react-native';
+import i18n from '../src/i18n';
 import { validateCycle } from '../src/validation';
 
 export default function CycleFormModal({ visible, onSubmit, onCancel }) {
@@ -32,7 +33,7 @@ export default function CycleFormModal({ visible, onSubmit, onCancel }) {
       pedEnd,
     });
     if (msg) {
-      Alert.alert('Validation', msg);
+      Alert.alert(i18n.t('validation.title'), msg);
       return;
     }
     onSubmit({
@@ -48,27 +49,27 @@ export default function CycleFormModal({ visible, onSubmit, onCancel }) {
     <Modal visible={visible} transparent>
       <View style={{ flex:1, justifyContent:'center', backgroundColor:'rgba(0,0,0,0.5)' }}>
         <View style={{ margin:20, padding:20, backgroundColor:'white' }}>
-          <Text>Cycle seconds</Text>
+          <Text>{i18n.t('cycleForm.cycleSeconds')}</Text>
           <TextInput value={cycleSeconds} onChangeText={setCycleSeconds} keyboardType="numeric" />
-          <Text>t0 ISO</Text>
+          <Text>{i18n.t('cycleForm.t0')}</Text>
           <TextInput value={t0} onChangeText={setT0} />
-          <Text>Main green start/end</Text>
+          <Text>{i18n.t('cycleForm.main')}</Text>
           <View style={{ flexDirection:'row' }}>
             <TextInput style={{ flex:1 }} value={mainStart} onChangeText={setMainStart} keyboardType="numeric" />
             <TextInput style={{ flex:1 }} value={mainEnd} onChangeText={setMainEnd} keyboardType="numeric" />
           </View>
-          <Text>Secondary green start/end</Text>
+          <Text>{i18n.t('cycleForm.secondary')}</Text>
           <View style={{ flexDirection:'row' }}>
             <TextInput style={{ flex:1 }} value={secStart} onChangeText={setSecStart} keyboardType="numeric" />
             <TextInput style={{ flex:1 }} value={secEnd} onChangeText={setSecEnd} keyboardType="numeric" />
           </View>
-          <Text>Pedestrian green start/end</Text>
+          <Text>{i18n.t('cycleForm.pedestrian')}</Text>
           <View style={{ flexDirection:'row' }}>
             <TextInput style={{ flex:1 }} value={pedStart} onChangeText={setPedStart} keyboardType="numeric" />
             <TextInput style={{ flex:1 }} value={pedEnd} onChangeText={setPedEnd} keyboardType="numeric" />
           </View>
-          <Button title="Save" onPress={save} disabled={!!error} />
-          <Button title="Cancel" onPress={onCancel} />
+          <Button title={i18n.t('common.save')} onPress={save} disabled={!!error} />
+          <Button title={i18n.t('common.cancel')} onPress={onCancel} />
         </View>
       </View>
     </Modal>

--- a/components/DrivingHUD.js
+++ b/components/DrivingHUD.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
+import i18n from '../src/i18n';
 
 export default function DrivingHUD({
   maneuver,
@@ -15,19 +16,28 @@ export default function DrivingHUD({
     <SafeAreaView style={styles.container} pointerEvents="none">
       <View style={styles.maneuvers}>
         <Text testID="hud-maneuver" style={styles.text}>
-          {maneuver ? `${maneuver} in ${Math.round(distance)}m` : ''}
+          {maneuver
+            ? i18n.t('hud.maneuver', {
+                maneuver,
+                distance: Math.round(distance),
+              })
+            : ''}
         </Text>
       </View>
       <View style={styles.speedPanel}>
-        <Text testID="hud-speed" style={styles.text}>Speed: {speedKmh}</Text>
-        <Text testID="hud-speed-limit" style={styles.text}>Limit: {limit}</Text>
+        <Text testID="hud-speed" style={styles.text}>
+          {i18n.t('hud.speed', { speed: speedKmh })}
+        </Text>
+        <Text testID="hud-speed-limit" style={styles.text}>
+          {i18n.t('hud.limit', { limit })}
+        </Text>
       </View>
       <View style={styles.streetPanel}>
         <Text testID="hud-street" style={styles.text}>{street}</Text>
       </View>
       <View style={styles.etaPanel}>
         <Text testID="hud-eta" style={styles.text}>
-          ETA: {eta ? Math.round(eta) : '--'}s
+          {i18n.t('hud.eta', { eta: eta ? Math.round(eta) : '--' })}
         </Text>
       </View>
     </SafeAreaView>

--- a/components/LightFormModal.js
+++ b/components/LightFormModal.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Modal, View, Text, TextInput, Button, Alert } from 'react-native';
+import i18n from '../src/i18n';
 import { validateLight } from '../src/validation';
 
 export default function LightFormModal({ visible, coordinate, onSubmit, onCancel }) {
@@ -10,7 +11,7 @@ export default function LightFormModal({ visible, coordinate, onSubmit, onCancel
   const save = () => {
     const msg = validateLight(name, direction);
     if (msg) {
-      Alert.alert('Validation', msg);
+      Alert.alert(i18n.t('validation.title'), msg);
       return;
     }
     onSubmit({
@@ -27,16 +28,21 @@ export default function LightFormModal({ visible, coordinate, onSubmit, onCancel
     <Modal visible={visible} transparent>
       <View style={{ flex:1, justifyContent:'center', backgroundColor:'rgba(0,0,0,0.5)' }}>
         <View style={{ margin:20, padding:20, backgroundColor:'white' }}>
-          <Text>Name</Text>
+          <Text>{i18n.t('lightForm.name')}</Text>
           <TextInput value={name} onChangeText={setName} />
-          <Text>Direction</Text>
+          <Text>{i18n.t('lightForm.direction')}</Text>
           <View style={{ flexDirection:'row', justifyContent:'space-around', marginVertical:10 }}>
             {['MAIN','SECONDARY','PEDESTRIAN'].map(d => (
-              <Button key={d} title={d} onPress={() => setDirection(d)} color={direction===d ? 'blue' : undefined} />
+              <Button
+                key={d}
+                title={i18n.t(`directions.${d}`)}
+                onPress={() => setDirection(d)}
+                color={direction===d ? 'blue' : undefined}
+              />
             ))}
           </View>
-          <Button title="Save" onPress={save} disabled={!!error} />
-          <Button title="Cancel" onPress={onCancel} />
+          <Button title={i18n.t('common.save')} onPress={save} disabled={!!error} />
+          <Button title={i18n.t('common.cancel')} onPress={onCancel} />
         </View>
       </View>
     </Modal>

--- a/src/__tests__/DrivingHUD.test.tsx
+++ b/src/__tests__/DrivingHUD.test.tsx
@@ -26,9 +26,9 @@ describe('DrivingHUD', () => {
     expect(root.findByProps({ testID: 'hud-maneuver' }).props.children).toContain('Turn left');
     expect(root.findByProps({ testID: 'hud-maneuver' }).props.children).toContain('100');
     expect(root.findByProps({ testID: 'hud-street' }).props.children).toBe('Main St');
-    const etaText = root.findByProps({ testID: 'hud-eta' }).props.children.join('');
+    const etaText = root.findByProps({ testID: 'hud-eta' }).props.children;
     expect(etaText).toContain('60');
-    const limitText = root.findByProps({ testID: 'hud-speed-limit' }).props.children.join('');
+    const limitText = root.findByProps({ testID: 'hud-speed-limit' }).props.children;
     expect(limitText).toContain('50');
   });
 });

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -30,4 +30,25 @@ describe('i18n translations', () => {
       'Recommend 40 km/h • next light in 100 m • window in 20 s'
     );
   });
+
+  it('translates validation messages', () => {
+    i18n.locale = 'en';
+    expect(i18n.t('validation.light.nameRequired')).toBe('Name is required');
+    i18n.locale = 'ru';
+    expect(i18n.t('validation.light.nameRequired')).toBe('Требуется название');
+  });
+
+  it('translates HUD speed text', () => {
+    i18n.locale = 'en';
+    expect(i18n.t('hud.speed', { speed: 50 })).toBe('Speed: 50');
+    i18n.locale = 'ru';
+    expect(i18n.t('hud.speed', { speed: 50 })).toBe('Скорость: 50');
+  });
+
+  it('translates menu labels', () => {
+    i18n.locale = 'en';
+    expect(i18n.t('menu.startNavigation')).toBe('Start Navigation');
+    i18n.locale = 'ru';
+    expect(i18n.t('menu.startNavigation')).toBe('Начать навигацию');
+  });
 });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -12,6 +12,45 @@ const translations = {
       addLight: 'Add Light',
       settings: 'Settings',
     },
+    validation: {
+      title: 'Validation',
+      light: {
+        nameRequired: 'Name is required',
+        directionInvalid: 'Direction is invalid',
+      },
+      cycle: {
+        numeric: 'All numeric fields must be valid numbers',
+        mainOrder: 'Main start must be less than end',
+        secondaryOrder: 'Secondary start must be less than end',
+        pedestrianOrder: 'Pedestrian start must be less than end',
+      },
+    },
+    hud: {
+      maneuver: '%{maneuver} in %{distance}m',
+      speed: 'Speed: %{speed}',
+      limit: 'Limit: %{limit}',
+      eta: 'ETA: %{eta}s',
+    },
+    common: {
+      save: 'Save',
+      cancel: 'Cancel',
+    },
+    lightForm: {
+      name: 'Name',
+      direction: 'Direction',
+    },
+    cycleForm: {
+      cycleSeconds: 'Cycle seconds',
+      t0: 't0 ISO',
+      main: 'Main green start/end',
+      secondary: 'Secondary green start/end',
+      pedestrian: 'Pedestrian green start/end',
+    },
+    directions: {
+      MAIN: 'MAIN',
+      SECONDARY: 'SECONDARY',
+      PEDESTRIAN: 'PEDESTRIAN',
+    },
   },
   ru: {
     speedBanner: {
@@ -22,6 +61,45 @@ const translations = {
       clearRoute: 'Очистить маршрут',
       addLight: 'Добавить светофор',
       settings: 'Настройки',
+    },
+    validation: {
+      title: 'Проверка',
+      light: {
+        nameRequired: 'Требуется название',
+        directionInvalid: 'Неверное направление',
+      },
+      cycle: {
+        numeric: 'Все числовые поля должны быть валидными числами',
+        mainOrder: 'Начало основного должно быть меньше конца',
+        secondaryOrder: 'Начало вторичного должно быть меньше конца',
+        pedestrianOrder: 'Начало пешеходного должно быть меньше конца',
+      },
+    },
+    hud: {
+      maneuver: '%{maneuver} через %{distance}м',
+      speed: 'Скорость: %{speed}',
+      limit: 'Лимит: %{limit}',
+      eta: 'ETA: %{eta}с',
+    },
+    common: {
+      save: 'Сохранить',
+      cancel: 'Отмена',
+    },
+    lightForm: {
+      name: 'Название',
+      direction: 'Направление',
+    },
+    cycleForm: {
+      cycleSeconds: 'Длина цикла',
+      t0: 't0 (ISO)',
+      main: 'Основной зелёный начало/конец',
+      secondary: 'Вторичный зелёный начало/конец',
+      pedestrian: 'Пешеходный зелёный начало/конец',
+    },
+    directions: {
+      MAIN: 'ОСНОВНОЙ',
+      SECONDARY: 'ВТОРОСТЕПЕННЫЙ',
+      PEDESTRIAN: 'ПЕШЕХОДНЫЙ',
     },
   },
 };

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,10 +1,12 @@
+import i18n from './i18n';
+
 export const validateLight = (name: string, direction: string): string | null => {
   if (!name.trim()) {
-    return 'Name is required';
+    return i18n.t('validation.light.nameRequired');
   }
   const allowed = ['MAIN', 'SECONDARY', 'PEDESTRIAN'];
   if (!allowed.includes(direction)) {
-    return 'Direction is invalid';
+    return i18n.t('validation.light.directionInvalid');
   }
   return null;
 };
@@ -30,16 +32,16 @@ export const validateCycle = ({
 }: CycleFields): string | null => {
   const values = [cycleSeconds, mainStart, mainEnd, secStart, secEnd, pedStart, pedEnd].map(Number);
   if (values.some(v => Number.isNaN(v))) {
-    return 'All numeric fields must be valid numbers';
+    return i18n.t('validation.cycle.numeric');
   }
   if (Number(mainStart) >= Number(mainEnd)) {
-    return 'Main start must be less than end';
+    return i18n.t('validation.cycle.mainOrder');
   }
   if (Number(secStart) >= Number(secEnd)) {
-    return 'Secondary start must be less than end';
+    return i18n.t('validation.cycle.secondaryOrder');
   }
   if (Number(pedStart) >= Number(pedEnd)) {
-    return 'Pedestrian start must be less than end';
+    return i18n.t('validation.cycle.pedestrianOrder');
   }
   return null;
 };


### PR DESCRIPTION
## Summary
- expand i18n translations with menu items, validation errors, HUD strings, and form labels in English and Russian
- hook validation and UI components into i18n instead of hard-coded strings
- test new translation keys and mock `expo-localization`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ada8b6dc748323ac8e14eb9c317c4c