### PR TITLE
feat: add network fetch helper and user-friendly errors

### DIFF
--- a/services/network.ts
+++ b/services/network.ts
@@ -1,0 +1,38 @@
+export interface FetchOptions extends RequestInit {
+  timeout?: number;
+}
+
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  options: FetchOptions = {}
+): Promise<Response> {
+  const { timeout = 10000, ...init } = options;
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    const res = await fetch(input, { ...init, signal: controller.signal });
+    if (!res.ok) {
+      let message = '';
+      try {
+        const data = await res.json();
+        message = data.message || JSON.stringify(data);
+      } catch {
+        try {
+          message = await res.text();
+        } catch {
+          /* ignore */
+        }
+      }
+      message = message || res.statusText || 'Unknown error';
+      throw new Error(`Request failed with status ${res.status}: ${message}`);
+    }
+    return res;
+  } catch (err: any) {
+    if (err.name === 'AbortError') {
+      throw new Error('Request timed out. Please try again.');
+    }
+    throw new Error(err.message || 'Network request failed.');
+  } finally {
+    clearTimeout(id);
+  }
+}

--- a/services/ors.js
+++ b/services/ors.js
@@ -1,3 +1,5 @@
+const { fetchWithTimeout } = require('./network');
+
 async function getRoute(start, end) {
   const apiKey = process.env.EXPO_PUBLIC_ORS_API_KEY;
   if (!apiKey) {
@@ -8,14 +10,12 @@ async function getRoute(start, end) {
 
   let res;
   try {
-    res = await fetch(url, { headers: { Authorization: apiKey } });
+    res = await fetchWithTimeout(url, {
+      headers: { Authorization: apiKey },
+    });
   } catch (err) {
-    throw new Error(`Failed to fetch route: ${err instanceof Error ? err.message : err}`);
-  }
-
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(`OpenRouteService error ${res.status}: ${message}`);
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Unable to fetch route. ${message}`);
   }
 
   const json = await res.json();

--- a/services/supabase.js
+++ b/services/supabase.js
@@ -1,9 +1,12 @@
 const { createClient } = require('@supabase/supabase-js');
+const { fetchWithTimeout } = require('./network');
 
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  fetch: fetchWithTimeout,
+});
 
 async function fetchLightsAndCycles() {
   const {
@@ -12,7 +15,11 @@ async function fetchLightsAndCycles() {
   } = await supabase.from('lights').select('*');
   if (lightsError) {
     console.error('Error fetching lights:', lightsError);
-    return { lights: [], cycles: [], error: lightsError };
+    return {
+      lights: [],
+      cycles: [],
+      error: new Error('Unable to load lights data. Please try again later.'),
+    };
   }
 
   const {
@@ -21,7 +28,11 @@ async function fetchLightsAndCycles() {
   } = await supabase.from('light_cycles').select('*');
   if (cyclesError) {
     console.error('Error fetching cycles:', cyclesError);
-    return { lights: lights || [], cycles: [], error: cyclesError };
+    return {
+      lights: lights || [],
+      cycles: [],
+      error: new Error('Unable to load cycle data. Please try again later.'),
+    };
   }
 
   return { lights: lights || [], cycles: cycles || [], error: null };

--- a/src/ors.test.ts
+++ b/src/ors.test.ts
@@ -29,7 +29,9 @@ describe('getRoute', () => {
         text: jest.fn().mockResolvedValue('server error'),
       } as any);
 
-    await expect(getRoute(start, end)).rejects.toThrow('OpenRouteService error 500: server error');
+    await expect(getRoute(start, end)).rejects.toThrow(
+      'Unable to fetch route. Request failed with status 500: server error'
+    );
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- wrap fetch with timeout and error parsing
- use shared network helper in OpenRouteService and Supabase services
- return human-friendly error messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add8e32b748323bc6dfa9dafb7164f