### PR TITLE
Add tests for UI components using React Native Testing Library

### DIFF
--- a/components/SpeedBanner.tsx
+++ b/components/SpeedBanner.tsx
@@ -15,8 +15,8 @@ export default function SpeedBanner({ speed, nearestDist, timeToWindow }: SpeedB
       <Text style={styles.text}>
         {i18n.t('speedBanner.recommendation', {
           speed: Math.round(speed),
-          distance: Math.round(nearestDist),
-          time: Math.round(timeToWindow),
+          distance: Math.round(nearestDist ?? 0),
+          time: Math.round(timeToWindow ?? 0),
         })}
       </Text>
     </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@babel/core": "^7.23.0",
         "@babel/preset-env": "^7.23.0",
         "@babel/preset-react": "^7.23.0",
+        "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.11",
         "@types/react": "^18.2.21",
         "@types/react-test-renderer": "^18.0.0",
@@ -3036,6 +3037,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -3093,6 +3104,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -4904,6 +4925,113 @@
         "@supabase/postgrest-js": "1.21.3",
         "@supabase/realtime-js": "2.15.1",
         "@supabase/storage-js": "^2.10.4"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.40",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
+      "integrity": "sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.5.tgz",
+      "integrity": "sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.5.tgz",
+      "integrity": "sha512-uQgGWt7GOrRLP1P7IwNWwK1WAQbq+m//ZY0yXygyfWp0rJlksMSLQAA4wYQC3b6wl3zfnchyTx+k3HZ5aPtCbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.0.5",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -7639,6 +7767,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -10395,6 +10533,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -11743,6 +11891,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -12725,6 +12887,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-test-renderer": "18.2.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "@testing-library/react-native": "^13.3.3"
   }
 }

--- a/src/__tests__/CarMarker.test.tsx
+++ b/src/__tests__/CarMarker.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('expo-localization');
+jest.mock('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  StyleSheet: { create: () => ({}), flatten: () => ({}) },
+}));
+
+jest.mock('react-native-maps', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Marker = ({ children, ...props }: any) => <View {...props}>{children}</View>;
+  return { Marker };
+});
+
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Svg = ({ children, ...props }: any) => <View {...props}>{children}</View>;
+  const Path = (props: any) => <View {...props} />;
+  return { __esModule: true, default: Svg, Path };
+});
+
+import CarMarker from '../../components/CarMarker';
+
+describe('CarMarker', () => {
+  it('renders marker with rotation', () => {
+    const { toJSON } = render(
+      <CarMarker coordinate={{ latitude: 1, longitude: 2 }} heading={45} />
+    );
+    const tree: any = toJSON();
+    expect(tree).not.toBeNull();
+    expect(tree.props.coordinate).toEqual({ latitude: 1, longitude: 2 });
+    const svg = tree.children[0];
+    expect(svg.props.style.transform[0].rotate).toBe('45deg');
+  });
+
+  it('returns null without coordinate', () => {
+    const { toJSON } = render(<CarMarker />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/src/__tests__/CycleFormModal.test.tsx
+++ b/src/__tests__/CycleFormModal.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+jest.mock('expo-localization');
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    Modal: 'Modal',
+    View: 'View',
+    Text: 'Text',
+    TextInput: 'TextInput',
+    Button: ({ title, onPress, disabled }: any) =>
+      React.createElement('Text', { onPress, disabled }, title),
+    Alert: { alert: jest.fn() },
+    StyleSheet: { create: () => ({}), flatten: () => ({}) },
+  };
+});
+
+import CycleFormModal from '../../components/CycleFormModal';
+
+describe('CycleFormModal', () => {
+  it('submits default values', () => {
+    const onSubmit = jest.fn();
+    const { getByText } = render(
+      <CycleFormModal visible onSubmit={onSubmit} onCancel={jest.fn()} />
+    );
+    fireEvent.press(getByText('Save'));
+    expect(onSubmit).toHaveBeenCalledWith({
+      cycle_seconds: 60,
+      t0_iso: expect.any(String),
+      main_green: [0, 10],
+      secondary_green: [10, 20],
+      ped_green: [20, 30],
+    });
+  });
+});

--- a/src/__tests__/DrivingHUD.test.tsx
+++ b/src/__tests__/DrivingHUD.test.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
+jest.mock('expo-localization');
 jest.mock('react-native', () => ({
   SafeAreaView: 'SafeAreaView',
   View: 'View',
   Text: 'Text',
-  StyleSheet: { create: () => ({}) },
+  StyleSheet: { create: () => ({}), flatten: () => ({}) },
 }));
 
 import DrivingHUD from '../../components/DrivingHUD';
 
 describe('DrivingHUD', () => {
   it('displays provided props', () => {
-    const tree = renderer.create(
+    const { getByTestId } = render(
       <DrivingHUD
         maneuver="Turn left"
         distance={100}
@@ -22,13 +23,9 @@ describe('DrivingHUD', () => {
         speedLimit={50}
       />
     );
-    const root = tree.root;
-    expect(root.findByProps({ testID: 'hud-maneuver' }).props.children).toContain('Turn left');
-    expect(root.findByProps({ testID: 'hud-maneuver' }).props.children).toContain('100');
-    expect(root.findByProps({ testID: 'hud-street' }).props.children).toBe('Main St');
-    const etaText = root.findByProps({ testID: 'hud-eta' }).props.children;
-    expect(etaText).toContain('60');
-    const limitText = root.findByProps({ testID: 'hud-speed-limit' }).props.children;
-    expect(limitText).toContain('50');
+    expect(getByTestId('hud-maneuver').props.children).toBe('Turn left in 100m');
+    expect(getByTestId('hud-street').props.children).toBe('Main St');
+    expect(getByTestId('hud-eta').props.children).toBe('ETA: 60s');
+    expect(getByTestId('hud-speed-limit').props.children).toBe('Limit: 50');
   });
 });

--- a/src/__tests__/LightFormModal.test.tsx
+++ b/src/__tests__/LightFormModal.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+jest.mock('expo-localization');
+jest.mock('react-native', () => {
+  const React = require('react');
+  return {
+    Modal: 'Modal',
+    View: 'View',
+    Text: 'Text',
+    TextInput: 'TextInput',
+    Button: ({ title, onPress, disabled }: any) =>
+      React.createElement('Text', { onPress, disabled }, title),
+    Alert: { alert: jest.fn() },
+    StyleSheet: { create: () => ({}), flatten: () => ({}) },
+  };
+});
+
+import LightFormModal from '../../components/LightFormModal';
+
+describe('LightFormModal', () => {
+  it('submits when name provided', () => {
+    const onSubmit = jest.fn();
+    const { getByText, getByDisplayValue } = render(
+      <LightFormModal
+        visible
+        coordinate={{ latitude: 1, longitude: 2 }}
+        onSubmit={onSubmit}
+        onCancel={jest.fn()}
+      />
+    );
+    const input = getByDisplayValue('');
+    fireEvent.changeText(input, 'Test');
+    fireEvent.press(getByText('Save'));
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Test',
+      direction: 'MAIN',
+      lat: 1,
+      lon: 2,
+    });
+  });
+});

--- a/src/__tests__/MainMenu.test.tsx
+++ b/src/__tests__/MainMenu.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('expo-localization');
+jest.mock('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  TouchableOpacity: 'TouchableOpacity',
+  StyleSheet: { create: () => ({}), flatten: () => ({}) },
+}));
+
+import MainMenu from '../../components/MainMenu';
+
+describe('MainMenu', () => {
+  const noop = jest.fn();
+
+  it('renders when visible', () => {
+    const { getByTestId, getByText } = render(
+      <MainMenu
+        visible
+        onStartNavigation={noop}
+        onClearRoute={noop}
+        onAddLight={noop}
+        onSettings={noop}
+      />
+    );
+    expect(getByTestId('main-menu')).toBeTruthy();
+    expect(getByText('Start Navigation')).toBeTruthy();
+  });
+
+  it('returns null when not visible', () => {
+    const { queryByTestId } = render(
+      <MainMenu
+        visible={false}
+        onStartNavigation={noop}
+        onClearRoute={noop}
+        onAddLight={noop}
+        onSettings={noop}
+      />
+    );
+    expect(queryByTestId('main-menu')).toBeNull();
+  });
+});

--- a/src/__tests__/SpeedBanner.test.tsx
+++ b/src/__tests__/SpeedBanner.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('expo-localization');
+jest.mock('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  StyleSheet: { create: () => ({}), flatten: () => ({}) },
+}));
+
+import SpeedBanner from '../../components/SpeedBanner';
+
+describe('SpeedBanner', () => {
+  it('renders recommendation text', () => {
+    const { getByText } = render(
+      <SpeedBanner speed={30} nearestDist={100} timeToWindow={20} />
+    );
+    expect(
+      getByText('Recommend 30 km/h • next light in 100 m • window in 20 s')
+    ).toBeTruthy();
+  });
+
+  it('returns null when no speed', () => {
+    const { toJSON } = render(<SpeedBanner />);
+    expect(toJSON()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add @testing-library/react-native for component testing
- cover CarMarker, CycleFormModal, LightFormModal, MainMenu, SpeedBanner and DrivingHUD with tests
- handle optional props in SpeedBanner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68addc77c2288323af5e462280599e9c