### PR TITLE
Add Firebase analytics tracking

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,6 +12,7 @@ import { getRoute } from './services/ors';
 import { mapColorForRuntime, getGreenWindow } from './src/domain/phases';
 import { projectLightsToRoute } from './src/domain/matching';
 import { pickSpeed, applyHysteresis } from './src/domain/advisor';
+import { trackEvent } from './services/analytics';
 
 export default function App() {
   const mapRef = useRef(null);
@@ -37,6 +38,7 @@ export default function App() {
   const [menuVisible, setMenuVisible] = useState(false);
 
   const handleStartNavigation = () => {
+    trackEvent('navigation_start');
     setMenuVisible(false);
   };
 
@@ -62,6 +64,7 @@ export default function App() {
   };
 
   const handleSettings = () => {
+    trackEvent('settings_change');
     setMenuVisible(false);
   };
 
@@ -140,6 +143,7 @@ export default function App() {
       .select()
       .single();
     if (!error) {
+      trackEvent('light_added', { id: inserted.id });
       setLights(l => [...l, inserted]);
       setLightModal(null);
       setCycleModal({ light_id: inserted.id });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.56.0",
         "expo": "^53.0.0",
+        "expo-firebase-analytics": "^8.0.0",
         "expo-localization": "^16.1.6",
         "expo-location": "^18.0.0",
         "i18n-js": "^4.5.1",
@@ -4747,6 +4748,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
+      "license": "MIT"
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.79.5",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
@@ -7056,6 +7063,241 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-firebase-analytics": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/expo-firebase-analytics/-/expo-firebase-analytics-8.0.0.tgz",
+      "integrity": "sha512-nWYa5vm2BX+qXrB0UQPMb0vh+QSGpx9G78TetRQAa+M+96j5Y0qUEsSKWkKvkICFF8ItnhNz2vdDNWZrMLefnw==",
+      "deprecated": "See alternatives: https://docs.expo.dev/guides/using-analytics/",
+      "license": "MIT",
+      "dependencies": {
+        "expo-firebase-core": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-firebase-core": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-firebase-core/-/expo-firebase-core-6.0.0.tgz",
+      "integrity": "sha512-ZMcvRxKuAjZ0V4+VCuYKQ9P3Br8nGUORCbG41ewyLnLXBwov85AdBx4/5lA7T5cX1oOmv2fKMnU3gqCR+s6Veg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-constants": "~14.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/@expo/config": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-7.0.3.tgz",
+      "integrity": "sha512-joVtB5o+NF40Tmsdp65UzryRtbnCuMbXkVO4wJnNJO4aaK0EYLdHCYSewORVqNcDfGN0LphQr8VTG2npbd9CJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~5.0.3",
+        "@expo/config-types": "^47.0.0",
+        "@expo/json-file": "8.2.36",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.3.2",
+        "slugify": "^1.3.4",
+        "sucrase": "^3.20.0"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/@expo/config-plugins": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-5.0.4.tgz",
+      "integrity": "sha512-vzUcVpqOMs3h+hyRdhGwk+eGIOhXa5xYdd92yO17RMNHav3v/+ekMbs7XA2c3lepMO8Yd4/5hqmRw9ZTL6jGzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^47.0.0",
+        "@expo/json-file": "8.2.36",
+        "@expo/plist": "0.0.18",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "@react-native/normalize-color": "^2.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.1",
+        "find-up": "~5.0.0",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.5",
+        "slash": "^3.0.0",
+        "xcode": "^3.0.1",
+        "xml2js": "0.4.23"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/@expo/config-types": {
+      "version": "47.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-47.0.0.tgz",
+      "integrity": "sha512-r0pWfuhkv7KIcXMUiNACJmJKKwlTBGMw9VZHNdppS8/0Nve8HZMTkNRFQzTHW1uH3pBj8jEXpyw/2vSWDHex9g==",
+      "license": "MIT"
+    },
+    "node_modules/expo-firebase-core/node_modules/@expo/config/node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/@expo/json-file": {
+      "version": "8.2.36",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.36.tgz",
+      "integrity": "sha512-tOZfTiIFA5KmMpdW9KF7bc6CFiGjb0xnbieJhTGlHrLL+ps2G0OkqmuZ3pFEXBOMnJYUVpnSy++52LFxvpa5ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^1.0.1",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/@expo/plist": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
+      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.0",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/expo-constants": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-14.0.2.tgz",
+      "integrity": "sha512-wzV3nrzTXTI8yG0tfas3fnqCfKV6YE+1GphEREyVDAShEB6mBInX1b6HgtpHFy2wOtnml+lPVmTCeGtjjLnZhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~7.0.2",
+        "uuid": "^3.3.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/getenv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
+      "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/expo-firebase-core/node_modules/xmlbuilder": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/expo-font": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.56.0",
     "expo": "^53.0.0",
+    "expo-firebase-analytics": "^8.0.0",
     "expo-localization": "^16.1.6",
     "expo-location": "^18.0.0",
     "i18n-js": "^4.5.1",
@@ -22,17 +23,17 @@
     "react-native-svg": "15.2.0"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.11",
-    "@types/react": "^18.2.21",
-    "@types/react-test-renderer": "^18.0.0",
     "@babel/core": "^7.23.0",
     "@babel/preset-env": "^7.23.0",
     "@babel/preset-react": "^7.23.0",
+    "@testing-library/react-native": "^13.3.3",
+    "@types/jest": "^29.5.11",
+    "@types/react": "^18.2.21",
+    "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.7.0",
-    "react-test-renderer": "18.2.0",
     "jest": "^29.7.0",
+    "react-test-renderer": "18.2.0",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.6.3",
-    "@testing-library/react-native": "^13.3.3"
+    "typescript": "^5.6.3"
   }
 }

--- a/services/analytics.ts
+++ b/services/analytics.ts
@@ -1,0 +1,9 @@
+import * as Analytics from 'expo-firebase-analytics';
+
+export async function trackEvent(name: string, params?: Record<string, any>): Promise<void> {
+  try {
+    await Analytics.logEvent(name, params);
+  } catch (err) {
+    console.warn('Failed to log analytics event', err);
+  }
+}


### PR DESCRIPTION
## Summary
- install expo-firebase-analytics SDK and add trackEvent helper
- log analytics events for navigation start, settings interactions, and light addition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade74600248323bc1acde237f8c5fd