### PR TITLE
feat: add premium subscription support

### DIFF
--- a/__mocks__/expo-in-app-purchases.ts
+++ b/__mocks__/expo-in-app-purchases.ts
@@ -1,0 +1,4 @@
+export async function connectAsync() { return { responseCode: 0 }; }
+export async function disconnectAsync() {}
+export async function getPurchaseHistoryAsync() { return { results: [] }; }
+export async function purchaseItemAsync(_id: string) { return { responseCode: 0 }; }

--- a/components/DrivingHUD.tsx
+++ b/components/DrivingHUD.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
 import i18n from '../src/i18n';
+import { usePremium } from '../src/premium/subscription';
+import {
+  PremiumFeature,
+  requiresPremium,
+} from '../src/premium/features';
 
 export interface DrivingHUDProps {
   maneuver?: string;
@@ -19,6 +24,7 @@ export default function DrivingHUD({
   speed,
   speedLimit,
 }: DrivingHUDProps) {
+  const { isPremium } = usePremium();
   const speedKmh = Math.round(speed || 0);
   const limit = speedLimit ? Math.round(speedLimit) : '--';
   return (
@@ -33,14 +39,16 @@ export default function DrivingHUD({
             : ''}
         </Text>
       </View>
-      <View style={styles.speedPanel}>
-        <Text testID="hud-speed" style={styles.text}>
-          {i18n.t('hud.speed', { speed: speedKmh })}
-        </Text>
-        <Text testID="hud-speed-limit" style={styles.text}>
-          {i18n.t('hud.limit', { limit })}
-        </Text>
-      </View>
+      {isPremium || !requiresPremium(PremiumFeature.SpeedPanel) ? (
+        <View style={styles.speedPanel}>
+          <Text testID="hud-speed" style={styles.text}>
+            {i18n.t('hud.speed', { speed: speedKmh })}
+          </Text>
+          <Text testID="hud-speed-limit" style={styles.text}>
+            {i18n.t('hud.limit', { limit })}
+          </Text>
+        </View>
+      ) : null}
       <View style={styles.streetPanel}>
         <Text testID="hud-street" style={styles.text}>{street}</Text>
       </View>

--- a/components/MainMenu.tsx
+++ b/components/MainMenu.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import i18n from '../src/i18n';
+import { usePremium } from '../src/premium/subscription';
+import {
+  PremiumFeature,
+  requiresPremium,
+} from '../src/premium/features';
 
 export interface MainMenuProps {
   visible: boolean;
@@ -17,6 +22,7 @@ export default function MainMenu({
   onAddLight,
   onSettings,
 }: MainMenuProps) {
+  const { isPremium } = usePremium();
   if (!visible) return null;
   return (
     <View style={styles.container} testID="main-menu">
@@ -26,9 +32,11 @@ export default function MainMenu({
       <TouchableOpacity onPress={onClearRoute} style={styles.item}>
         <Text style={styles.text}>{i18n.t('menu.clearRoute')}</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={onAddLight} style={styles.item}>
-        <Text style={styles.text}>{i18n.t('menu.addLight')}</Text>
-      </TouchableOpacity>
+      {isPremium || !requiresPremium(PremiumFeature.AddLight) ? (
+        <TouchableOpacity onPress={onAddLight} style={styles.item}>
+          <Text style={styles.text}>{i18n.t('menu.addLight')}</Text>
+        </TouchableOpacity>
+      ) : null}
       <TouchableOpacity onPress={onSettings} style={styles.item}>
         <Text style={styles.text}>{i18n.t('menu.settings')}</Text>
       </TouchableOpacity>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.56.0",
         "expo": "^53.0.0",
         "expo-firebase-analytics": "^8.0.0",
+        "expo-in-app-purchases": "^14.5.0",
         "expo-localization": "^16.1.6",
         "expo-location": "^18.0.0",
         "i18n-js": "^4.5.1",
@@ -7311,6 +7312,15 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-in-app-purchases": {
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/expo-in-app-purchases/-/expo-in-app-purchases-14.5.0.tgz",
+      "integrity": "sha512-rsVPH6fOoU+mzjn80IFLz5f4gxEHLxXv+Pl4Dwblc5IDYvKTaUvTljNuaVmWESZSjDOMBT1JUAYRAlMRfBWOcg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "18.2.0",
     "react-native": "0.74.5",
     "react-native-maps": "1.14.0",
-    "react-native-svg": "15.2.0"
+    "react-native-svg": "15.2.0",
+    "expo-in-app-purchases": "^14.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/src/__tests__/DrivingHUD.test.tsx
+++ b/src/__tests__/DrivingHUD.test.tsx
@@ -8,6 +8,9 @@ jest.mock('react-native', () => ({
   Text: 'Text',
   StyleSheet: { create: () => ({}), flatten: () => ({}) },
 }));
+jest.mock('../premium/subscription', () => ({
+  usePremium: () => ({ isPremium: true }),
+}));
 
 import DrivingHUD from '../../components/DrivingHUD';
 

--- a/src/premium/features.ts
+++ b/src/premium/features.ts
@@ -1,0 +1,13 @@
+export enum PremiumFeature {
+  AddLight = 'addLight',
+  SpeedPanel = 'speedPanel',
+}
+
+const premiumFeatures: Record<PremiumFeature, boolean> = {
+  [PremiumFeature.AddLight]: true,
+  [PremiumFeature.SpeedPanel]: true,
+};
+
+export function requiresPremium(feature: PremiumFeature): boolean {
+  return premiumFeatures[feature];
+}

--- a/src/premium/subscription.ts
+++ b/src/premium/subscription.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import * as InAppPurchases from 'expo-in-app-purchases';
+
+const SUBSCRIPTION_ID = 'premium_subscription';
+
+export async function purchasePremium() {
+  await InAppPurchases.purchaseItemAsync(SUBSCRIPTION_ID);
+}
+
+export function usePremium() {
+  const [isPremium, setPremium] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    async function init() {
+      try {
+        await InAppPurchases.connectAsync();
+        const history = await InAppPurchases.getPurchaseHistoryAsync();
+        const active = history.results?.some(r => r.productId === SUBSCRIPTION_ID);
+        if (mounted) setPremium(!!active);
+      } catch (e) {
+        console.warn('IAP error', e);
+      }
+    }
+    init();
+    return () => {
+      mounted = false;
+      InAppPurchases.disconnectAsync();
+    };
+  }, []);
+
+  return { isPremium };
+}


### PR DESCRIPTION
## Summary
- add premium feature flags and subscription hook backed by Expo In-App Purchases
- gate MainMenu and DrivingHUD controls behind premium checks
- mock in-app purchase module and update DrivingHUD test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adebdbc748832391a77a84df8cb337