### PR TITLE
feat: add camera screen with traffic light detection

### DIFF
--- a/components/CameraScreen.tsx
+++ b/components/CameraScreen.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Camera, CameraType } from 'expo-camera';
+import { detectTrafficLight, TrafficLightDetection } from '../services/trafficLightDetector';
+
+const CameraScreen: React.FC = () => {
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [detection, setDetection] = useState<TrafficLightDetection | null>(null);
+  const cameraRef = useRef<Camera | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Camera.requestCameraPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null;
+    if (isRecording) {
+      interval = setInterval(async () => {
+        if (!cameraRef.current) return;
+        try {
+          const photo = await cameraRef.current.takePictureAsync({ skipProcessing: true, base64: true });
+          const result = await detectTrafficLight(photo);
+          setDetection(result);
+        } catch (e) {
+          console.warn('Capture failed', e);
+        }
+      }, 1000);
+    }
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [isRecording]);
+
+  if (hasPermission === null) {
+    return (
+      <View style={styles.centered}>
+        <Text>Requesting camera permission...</Text>
+      </View>
+    );
+  }
+
+  if (hasPermission === false) {
+    return (
+      <View style={styles.centered}>
+        <Text>No access to camera</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Camera style={styles.camera} type={CameraType.back} ref={cameraRef} />
+      {detection && (
+        <View style={styles.result}>
+          <Text style={styles.resultText}>Color: {detection.color}</Text>
+          <Text style={styles.resultText}>
+            Box: {detection.boundingBox.x.toFixed(2)},{detection.boundingBox.y.toFixed(2)}
+          </Text>
+        </View>
+      )}
+      <TouchableOpacity
+        style={[styles.button, isRecording ? styles.buttonStop : null]}
+        onPress={() => setIsRecording(v => !v)}
+      >
+        <Text style={styles.buttonText}>{isRecording ? 'Stop' : 'Start'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default CameraScreen;
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  camera: { flex: 1 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  button: {
+    position: 'absolute',
+    bottom: 40,
+    alignSelf: 'center',
+    backgroundColor: '#4CAF50',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 25,
+  },
+  buttonStop: {
+    backgroundColor: '#E53935',
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 16,
+  },
+  result: {
+    position: 'absolute',
+    top: 40,
+    left: 20,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    padding: 10,
+    borderRadius: 8,
+  },
+  resultText: {
+    color: 'white',
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.56.0",
         "expo": "^53.0.0",
+        "expo-camera": "^15.0.0",
         "expo-firebase-analytics": "^8.0.0",
         "expo-in-app-purchases": "^14.5.0",
         "expo-localization": "^16.1.6",
@@ -7040,6 +7041,18 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "15.0.16",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-15.0.16.tgz",
+      "integrity": "sha512-FLE02DMqkjwsb7IugKAqQvBe6s+TCQeb5LupO1+r//wAhBwmHncOrc6zV95ZEC2f9PTPK34nFH/s8CDGiVzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "expo-firebase-analytics": "^8.0.0",
     "expo-localization": "^16.1.6",
     "expo-location": "^18.0.0",
+    "expo-camera": "^15.0.0",
     "i18n-js": "^4.5.1",
     "metro": "^0.82.0",
     "react": "18.2.0",

--- a/services/trafficLightDetector.ts
+++ b/services/trafficLightDetector.ts
@@ -1,0 +1,22 @@
+
+export interface TrafficLightDetection {
+  color: 'red' | 'yellow' | 'green';
+  boundingBox: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+}
+
+// Placeholder for TFLite/ML Kit integration. Replace with actual model inference.
+export async function detectTrafficLight(
+  photo: { base64?: string } | null,
+): Promise<TrafficLightDetection | null> {
+  if (!photo) return null;
+  // TODO: integrate TFLite/ML Kit model to detect traffic lights
+  return {
+    color: 'red',
+    boundingBox: { x: 0.5, y: 0.5, width: 0.1, height: 0.2 },
+  };
+}


### PR DESCRIPTION
## Summary
- add CameraScreen with start/stop controls and traffic light detection stub
- introduce traffic light detector service stub
- include expo-camera dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf14b2ccc832382adc5303cb03967