### PR TITLE
feat: upload light cycles to Supabase

### DIFF
--- a/components/CameraScreen.tsx
+++ b/components/CameraScreen.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Camera, CameraType } from 'expo-camera';
 import { detectTrafficLight, TrafficLightDetection } from '../services/trafficLightDetector';
+import { uploadCycle } from '../services/uploadLightData';
 
 const CameraScreen: React.FC = () => {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
@@ -12,6 +13,7 @@ const CameraScreen: React.FC = () => {
   const [colorStartTime, setColorStartTime] = useState<number | null>(null);
   const cameraRef = useRef<Camera | null>(null);
   const colorTimeline = useRef<{ color: string; timestamp: number }[]>([]);
+  const lightId = 1; // TODO: supply actual light id
 
   useEffect(() => {
     (async () => {
@@ -86,6 +88,11 @@ const CameraScreen: React.FC = () => {
               await AsyncStorage.setItem('colorPhases', JSON.stringify(phases));
             } catch (e) {
               console.warn('Saving phases failed', e);
+            }
+            try {
+              await uploadCycle(lightId, phases);
+            } catch (e) {
+              console.warn('Uploading cycle failed', e);
             }
           } else {
             colorTimeline.current = [];

--- a/services/uploadLightData.ts
+++ b/services/uploadLightData.ts
@@ -1,0 +1,21 @@
+import { supabase } from './supabase';
+
+export interface Phase {
+  color: string;
+  duration: number;
+}
+
+/**
+ * Uploads a cycle for a specific traffic light to Supabase.
+ * @param lightId - Identifier of the traffic light.
+ * @param phases - List of color phases with their durations.
+ */
+export async function uploadCycle(lightId: number | string, phases: Phase[]) {
+  const { error } = await supabase
+    .from('light_cycles')
+    .insert({ light_id: lightId, phases }); // entries can be validated via Supabase dashboard
+  if (error) {
+    console.error('Failed to upload cycle', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add uploadLightData service with `uploadCycle`
- send recorded traffic light phases to Supabase when recording stops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf66120a8832385de7d9b2228d5dc