### PR TITLE
refactor: extract styles to stylesheet

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS
+
+This repository contains a React Native (Expo) application.
+
+## Structure
+- `components/` – UI components written in TSX.
+- `src/` – application logic and tests under `src/__tests__`.
+- `services/` – service modules for networking and domain logic.
+- `assets/` – static images and resources.
+
+## Guidelines
+- Use functional components with hooks.
+- Define component styles via `StyleSheet.create` blocks.
+- Keep code formatted with Prettier/ESLint for TS/JS files.
+- Python files, if added, must be formatted with `black` and sorted with `isort`.
+
+## Checks
+Run these commands before committing:
+
+```bash
+pre-commit run --files <files>
+npm test
+```
+
+Tests should pass and formatting hooks should run on the changed files.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Minimal React Native (Expo) client showing a map with a car marker and driving HUD.
 
+## Recent changes
+
+- Added traffic light management forms for lights and cycles.
+- Introduced camera screen with traffic light detection.
+- Integrated premium subscription flow and analytics tracking.
+
 ## Environment
 
 Set the following environment variables for API access:

--- a/components/CycleFormModal.tsx
+++ b/components/CycleFormModal.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { Modal, View, Text, TextInput, Button, Alert } from 'react-native';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Button,
+  Alert,
+  StyleSheet,
+} from 'react-native';
 import i18n from '../src/i18n';
 import { validateCycle } from '../src/validation';
 
@@ -61,26 +69,61 @@ export default function CycleFormModal({ visible, onSubmit, onCancel }: CycleFor
 
   return (
     <Modal visible={visible} transparent>
-      <View style={{ flex:1, justifyContent:'center', backgroundColor:'rgba(0,0,0,0.5)' }}>
-        <View style={{ margin:20, padding:20, backgroundColor:'white' }}>
+      <View style={styles.container}>
+        <View style={styles.modal}>
           <Text>{i18n.t('cycleForm.cycleSeconds')}</Text>
-          <TextInput value={cycleSeconds} onChangeText={setCycleSeconds} keyboardType="numeric" />
+          <TextInput
+            style={styles.input}
+            value={cycleSeconds}
+            onChangeText={setCycleSeconds}
+            keyboardType="numeric"
+          />
           <Text>{i18n.t('cycleForm.t0')}</Text>
-          <TextInput value={t0} onChangeText={setT0} />
+          <TextInput style={styles.input} value={t0} onChangeText={setT0} />
           <Text>{i18n.t('cycleForm.main')}</Text>
-          <View style={{ flexDirection:'row' }}>
-            <TextInput style={{ flex:1 }} value={mainStart} onChangeText={setMainStart} keyboardType="numeric" />
-            <TextInput style={{ flex:1 }} value={mainEnd} onChangeText={setMainEnd} keyboardType="numeric" />
+          <View style={styles.row}>
+            <TextInput
+              style={[styles.input, styles.rowInput]}
+              value={mainStart}
+              onChangeText={setMainStart}
+              keyboardType="numeric"
+            />
+            <TextInput
+              style={[styles.input, styles.rowInput]}
+              value={mainEnd}
+              onChangeText={setMainEnd}
+              keyboardType="numeric"
+            />
           </View>
           <Text>{i18n.t('cycleForm.secondary')}</Text>
-          <View style={{ flexDirection:'row' }}>
-            <TextInput style={{ flex:1 }} value={secStart} onChangeText={setSecStart} keyboardType="numeric" />
-            <TextInput style={{ flex:1 }} value={secEnd} onChangeText={setSecEnd} keyboardType="numeric" />
+          <View style={styles.row}>
+            <TextInput
+              style={[styles.input, styles.rowInput]}
+              value={secStart}
+              onChangeText={setSecStart}
+              keyboardType="numeric"
+            />
+            <TextInput
+              style={[styles.input, styles.rowInput]}
+              value={secEnd}
+              onChangeText={setSecEnd}
+              keyboardType="numeric"
+            />
           </View>
           <Text>{i18n.t('cycleForm.pedestrian')}</Text>
-          <View style={{ flexDirection:'row' }}>
-            <TextInput style={{ flex:1 }} value={pedStart} onChangeText={setPedStart} keyboardType="numeric" />
-            <TextInput style={{ flex:1 }} value={pedEnd} onChangeText={setPedEnd} keyboardType="numeric" />
+          <View style={styles.row}>
+            <TextInput
+              style={[styles.input, styles.rowInput]}
+              value={pedStart}
+              onChangeText={setPedStart}
+              keyboardType="numeric"
+            />
+            <TextInput
+              style={[styles.input, styles.rowInput]}
+              value={pedEnd}
+              onChangeText={setPedEnd}
+              keyboardType="numeric"
+            />
           </View>
           <Button title={i18n.t('common.save')} onPress={save} disabled={!!error} />
           <Button title={i18n.t('common.cancel')} onPress={onCancel} />
@@ -89,3 +132,23 @@ export default function CycleFormModal({ visible, onSubmit, onCancel }: CycleFor
     </Modal>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  modal: {
+    margin: 20,
+    padding: 20,
+    backgroundColor: 'white',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  rowInput: {
+    flex: 1,
+  },
+  input: {},
+});

--- a/components/LightFormModal.tsx
+++ b/components/LightFormModal.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { Modal, View, Text, TextInput, Button, Alert } from 'react-native';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  Button,
+  Alert,
+  StyleSheet,
+} from 'react-native';
 import i18n from '../src/i18n';
 import { validateLight } from '../src/validation';
 
@@ -38,12 +46,12 @@ export default function LightFormModal({
 
   return (
     <Modal visible={visible} transparent>
-      <View style={{ flex:1, justifyContent:'center', backgroundColor:'rgba(0,0,0,0.5)' }}>
-        <View style={{ margin:20, padding:20, backgroundColor:'white' }}>
+      <View style={styles.container}>
+        <View style={styles.modal}>
           <Text>{i18n.t('lightForm.name')}</Text>
-          <TextInput value={name} onChangeText={setName} />
+          <TextInput style={styles.input} value={name} onChangeText={setName} />
           <Text>{i18n.t('lightForm.direction')}</Text>
-          <View style={{ flexDirection:'row', justifyContent:'space-around', marginVertical:10 }}>
+          <View style={[styles.row, styles.buttonRow]}>
             {['MAIN','SECONDARY','PEDESTRIAN'].map(d => (
               <Button
                 key={d}
@@ -60,3 +68,24 @@ export default function LightFormModal({
     </Modal>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  modal: {
+    margin: 20,
+    padding: 20,
+    backgroundColor: 'white',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  buttonRow: {
+    justifyContent: 'space-around',
+    marginVertical: 10,
+  },
+  input: {},
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"

--- a/src/types/expo-in-app-purchases.d.ts
+++ b/src/types/expo-in-app-purchases.d.ts
@@ -1,0 +1,12 @@
+declare module 'expo-in-app-purchases' {
+  export interface Purchase {
+    productId: string;
+  }
+  export interface PurchaseHistory {
+    results?: Purchase[];
+  }
+  export function connectAsync(): Promise<void>;
+  export function disconnectAsync(): Promise<void>;
+  export function getPurchaseHistoryAsync(): Promise<PurchaseHistory>;
+  export function purchaseItemAsync(productId: string): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- move inline styles in form modals to StyleSheet blocks
- add type declaration for expo-in-app-purchases
- document project structure and setup pre-commit hooks

## Testing
- `pre-commit run --files AGENTS.md README.md components/LightFormModal.tsx components/CycleFormModal.tsx .pre-commit-config.yaml pyproject.toml`
- `pre-commit run --files src/types/expo-in-app-purchases.d.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae032dfe808323bc09955975571df4