### PR TITLE
chore: guard ORS route parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 - Introduced camera screen with traffic light detection.
 - Integrated premium subscription flow and analytics tracking.
 - Switched traffic light detector to TFLite model inference.
+- Implemented fetch helper with timeout and error handling.
 
 ## Environment
 

--- a/services/ors.js
+++ b/services/ors.js
@@ -19,7 +19,10 @@ async function getRoute(start, end) {
   }
 
   const json = await res.json();
-  const feature = json.features[0];
+  const feature = json.features?.[0];
+  if (!feature) {
+    throw new Error('Route not found');
+  }
   const coords = feature.geometry.coordinates.map(([lon, lat]) => ({
     latitude: lat,
     longitude: lon,


### PR DESCRIPTION
## Summary
- guard against missing features when parsing ORS route
- document fetch helper addition in README

## Testing
- `pre-commit run --files README.md services/ors.js`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ed1892883238326f0b65b15620b