### PR TITLE
test: cover fetchWithTimeout error cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 - Integrated premium subscription flow and analytics tracking.
 - Switched traffic light detector to TFLite model inference.
 - Implemented fetch helper with timeout and error handling.
+- Guarded route parsing and handled route fetch errors gracefully.
 
 ## Environment
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/src/**/*.test.ts?(x)', '**/src/**/__tests__/**/*.ts?(x)'],
+  testMatch: [
+    '**/src/**/*.test.ts?(x)',
+    '**/src/**/__tests__/**/*.ts?(x)',
+    '**/services/**/*.test.ts?(x)',
+    '**/services/**/__tests__/**/*.ts?(x)',
+  ],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
     '^.+\\.(js|jsx)$': 'babel-jest',

--- a/services/__tests__/network.test.ts
+++ b/services/__tests__/network.test.ts
@@ -1,0 +1,57 @@
+import { fetchWithTimeout } from '../network';
+
+describe('fetchWithTimeout', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    jest.useRealTimers();
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('throws on timeout', async () => {
+    jest.useFakeTimers();
+
+    global.fetch = jest.fn((_, { signal }: any) => {
+      return new Promise((resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          const err: any = new Error('Aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const p = fetchWithTimeout('https://example.com', { timeout: 50 });
+    jest.advanceTimersByTime(60);
+    await expect(p).rejects.toThrow('Request timed out');
+  });
+
+  it('formats error for JSON responses', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Missing' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(fetchWithTimeout('https://example.com')).rejects.toThrow(
+      'Request failed with status 404: Missing',
+    );
+  });
+
+  it('formats error for text responses', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('bad json');
+      },
+      text: async () => 'Server error',
+    } as any);
+
+    await expect(fetchWithTimeout('https://example.com')).rejects.toThrow(
+      'Request failed with status 500: Server error',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- test network fetchWithTimeout for timeout and error responses
- extend Jest config to discover service tests
- document recent route fetch handling in README

## Testing
- `pre-commit run --files services/__tests__/network.test.ts jest.config.cjs README.md`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ae169e31388323b83ce3311c05e7a2