### PR TITLE
fix: clarify speed banner recommendation text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,12 @@
 This repository contains a React Native (Expo) application.
 
 ## Structure
-- `components/` – UI components written in TSX.
-- `src/` – application logic and tests under `src/__tests__`.
-- `services/` – service modules for networking and domain logic.
+- `components/` – React Native UI components.
+- `src/` – application logic, translations under `src/locales`, and Jest tests in `src/__tests__`.
+- `services/` – networking helpers and domain services.
+- `domain/` – pure domain logic shared by services and components.
 - `assets/` – static images and resources.
+- `App.js` – application entry point; renders map, HUD, and menus.
 
 Run logic tests with Jest; coverage is generated under `coverage/`.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 - Switched traffic light detector to TFLite model inference.
 - Implemented fetch helper with timeout and error handling.
 - Guarded route parsing and handled route fetch errors gracefully.
+- Externalized translations into locale files and expanded component test coverage.
 
 ## Environment
 

--- a/src/__tests__/SpeedBanner.test.tsx
+++ b/src/__tests__/SpeedBanner.test.tsx
@@ -16,7 +16,7 @@ describe('SpeedBanner', () => {
       <SpeedBanner speed={30} nearestDist={100} timeToWindow={20} />
     );
     expect(
-      getByText('Recommend 30 km/h • next light in 100 m • window in 20 s')
+      getByText('Recommended 30 km/h • next light in 100 m • window in 20 s')
     ).toBeTruthy();
   });
 

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -27,7 +27,7 @@ describe('i18n translations', () => {
       time: 20,
     });
     expect(res).toBe(
-      'Recommend 40 km/h • next light in 100 m • window in 20 s'
+      'Recommended 40 km/h • next light in 100 m • window in 20 s'
     );
   });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,6 @@
 {
   "speedBanner": {
-    "recommendation": "Recommend %{speed} km/h • next light in %{distance} m • window in %{time} s"
+    "recommendation": "Recommended %{speed} km/h • next light in %{distance} m • window in %{time} s"
   },
   "menu": {
     "startNavigation": "Start Navigation",


### PR DESCRIPTION
## Summary
- clarify speed banner recommendation wording
- document translation/test updates

## Testing
- `pre-commit run --files AGENTS.md README.md src/locales/en.json src/__tests__/SpeedBanner.test.tsx src/i18n.test.ts`
- `CI=true npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68ae1a3c2de88323bc668688e37c79f4