### PR TITLE
docs: update README and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-This repository contains a React Native (Expo) application.
+This repository contains a React Native (Expo) application. New contributors can start by exploring the folders below to see how the app is assembled.
 
 ## Structure
 - `components/` – React Native UI components.
@@ -10,7 +10,14 @@ This repository contains a React Native (Expo) application.
 - `assets/` – static images and resources.
 - `App.js` – application entry point; renders map, HUD, and menus.
 
-Run logic tests with Jest; coverage is generated under `coverage/`.
+The app fetches routing data and traffic light information from remote APIs. Tests live beside the code they verify, and coverage outputs under `coverage/`.
+
+## Getting started
+- `npm install` – install dependencies.
+- `npx expo start` – launch the development server.
+- `npm test -- --coverage` – run the Jest suite with coverage.
+
+Consult `README.md` for environment variables and more detailed setup steps.
 
 ## Guidelines
 - Use functional components with hooks.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 - Implemented fetch helper with timeout and error handling.
 - Guarded route parsing and handled route fetch errors gracefully.
 - Externalized translations into locale files and expanded component test coverage.
+- Refined speed banner recommendation copy.
+- Improved route fetch error handling.
 
 ## Environment
 
@@ -34,7 +36,7 @@ npx expo start
 Run unit tests:
 
 ```
-npm test
+npm test -- --coverage
 ```
 
 ### Debug APK build


### PR DESCRIPTION
## Summary
- document refined speed banner copy and better route error handling
- clarify test coverage command in README
- expand AGENTS guide with project overview and setup steps

## Testing
- `pre-commit run --files README.md AGENTS.md`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aeb16d89308323965d1740b5c53b63