### PR TITLE
fix: correct HUD maneuver spacing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,10 @@ npm test -- --coverage
 ```
 
 Tests should pass and formatting hooks should run on the changed files.
+
+## For New Contributors
+- Start the app with `npm start` to launch the Expo dev server.
+- UI components live in `components/` and rely on hooks for state.
+- Core logic and translations live under `src/` (`src/i18n.ts` wires up `src/locales`).
+- Network and domain helpers are in `services/` and `domain/`.
+- Jest tests reside in `src/__tests__`; add tests alongside new features.

--- a/src/__tests__/DrivingHUD.test.tsx
+++ b/src/__tests__/DrivingHUD.test.tsx
@@ -26,7 +26,7 @@ describe('DrivingHUD', () => {
         speedLimit={50}
       />
     );
-    expect(getByTestId('hud-maneuver').props.children).toBe('Turn left in 100m');
+    expect(getByTestId('hud-maneuver').props.children).toBe('Turn left in 100 m');
     expect(getByTestId('hud-street').props.children).toBe('Main St');
     expect(getByTestId('hud-eta').props.children).toBe('ETA: 60s');
     expect(getByTestId('hud-speed-limit').props.children).toBe('Limit: 50');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,7 +22,7 @@
     }
   },
   "hud": {
-    "maneuver": "%{maneuver} in %{distance}m",
+    "maneuver": "%{maneuver} in %{distance} m",
     "speed": "Speed: %{speed}",
     "limit": "Limit: %{limit}",
     "eta": "ETA: %{eta}s"


### PR DESCRIPTION
## Summary
- adjust HUD maneuver string to include space before distance unit
- update DrivingHUD test for new translation
- add onboarding notes for new contributors

## Testing
- `pre-commit run --files AGENTS.md src/locales/en.json src/__tests__/DrivingHUD.test.tsx`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aeb16ed7008323bf302a3e1b740264