### PR TITLE
fix main direction color mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 - Implemented fetch helper with timeout and error handling.
 - Guarded route parsing and handled route fetch errors gracefully.
 - Externalized translations into locale files and expanded component test coverage.
+- Updated speed banner recommendation message.
 
 ## Environment
 

--- a/src/domain/AGENTS.md
+++ b/src/domain/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS - domain
+
+Domain logic is pure and framework-agnostic.
+
+## Guidelines
+- Keep functions side-effect free.
+- Ensure each utility has focused Jest tests.
+
+## Checks
+Run before committing changes in this directory:
+
+```bash
+pre-commit run --files <files>
+npm test -- src/domain/__tests__
+```

--- a/src/domain/__tests__/phases.test.ts
+++ b/src/domain/__tests__/phases.test.ts
@@ -20,7 +20,7 @@ describe('phases utilities', () => {
 
   it('mapColorForRuntime picks colors by phase', () => {
     const t0 = Date.parse(cycle.t0_iso) / 1000;
-    expect(mapColorForRuntime(cycle, 'MAIN', t0 + 5)).toBe('red');
+    expect(mapColorForRuntime(cycle, 'MAIN', t0 + 5)).toBe('green');
     expect(mapColorForRuntime(cycle, 'SECONDARY', t0 + 15)).toBe('green');
     expect(mapColorForRuntime(cycle, 'PEDESTRIAN', t0 + 25)).toBe('blue');
     expect(mapColorForRuntime(cycle, 'MAIN', t0 + 35)).toBe('gray');

--- a/src/domain/phases.ts
+++ b/src/domain/phases.ts
@@ -19,6 +19,6 @@ export function mapColorForRuntime(
   const isGreen = phase >= gs && phase <= ge;
   if (dir === 'PEDESTRIAN') return isGreen ? 'blue' : 'gray';
   if (dir === 'SECONDARY') return isGreen ? 'green' : 'gray';
-  if (dir === 'MAIN') return isGreen ? 'red' : 'gray';
+  if (dir === 'MAIN') return isGreen ? 'green' : 'gray';
   return 'gray';
 }


### PR DESCRIPTION
## Summary
- map main direction to green in runtime color mapping
- update phases test and domain AGENTS guidance
- note speed banner message change in README

## Testing
- `npm test -- src/domain/__tests__/phases.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aeb170859483239ec0ba63c71723fd