### PR TITLE
fix: pin metro and add file logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 
 ## Recent changes
 
+- Fixed HUD maneuver spacing and updated localization string spacing.
 - Added traffic light management forms for lights and cycles.
 - Introduced camera screen with traffic light detection.
 - Integrated premium subscription flow and analytics tracking.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "expo-localization": "^16.1.6",
         "expo-location": "^18.0.0",
         "i18n-js": "^4.5.1",
-        "metro": "^0.82.0",
+        "metro": "0.81.1",
         "react": "18.2.0",
         "react-native": "0.74.5",
         "react-native-maps": "1.14.0",
@@ -553,6 +553,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
       "integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -569,6 +570,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
       "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -584,6 +586,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
       "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -599,6 +602,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
       "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -616,6 +620,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
       "integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -806,6 +811,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -929,6 +935,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
       "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -944,6 +951,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
       "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1119,6 +1127,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
@@ -1184,6 +1193,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
       "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1230,6 +1240,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
       "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.3",
@@ -1298,6 +1309,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
       "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1314,6 +1326,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
       "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1329,6 +1342,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
       "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1345,6 +1359,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
       "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1360,6 +1375,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
       "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1376,6 +1392,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
       "integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1455,6 +1472,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
       "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1500,6 +1518,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
       "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1515,6 +1534,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
       "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1547,6 +1567,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
       "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1565,6 +1586,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
       "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1597,6 +1619,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
       "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1661,6 +1684,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
       "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1756,6 +1780,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
       "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1881,6 +1906,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
       "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1897,6 +1923,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
       "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1987,6 +2014,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2002,6 +2030,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
       "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2036,6 +2065,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
       "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2051,6 +2081,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
       "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -2083,6 +2114,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
       "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -2099,6 +2131,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
       "integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.0",
@@ -2183,6 +2216,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2209,6 +2243,7 @@
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -5175,14 +5210,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6522,7 +6557,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dayjs": {
@@ -6904,6 +6939,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9730,9 +9766,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.0.tgz",
-      "integrity": "sha512-3rSgYWSx7G8IgmyG6jmBem5HvJRrLyxAU0nEBUqFRplyY7HYrfpDoRIb+syMeJlvdrNQHVvqG+tey3VCW+GLsQ==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.81.1.tgz",
+      "integrity": "sha512-fqRu4fg8ONW7VfqWFMGgKAcOuMzyoQah2azv9Y3VyFXAmG+AoTU6YIFWqAADESCGVWuWEIvxTJhMf3jxU6jwjA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -9746,28 +9782,28 @@
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "connect": "^3.6.5",
-        "debug": "^4.4.0",
+        "debug": "^2.2.0",
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "hermes-parser": "0.25.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
+        "jest-worker": "^29.6.3",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.82.0",
-        "metro-cache": "0.82.0",
-        "metro-cache-key": "0.82.0",
-        "metro-config": "0.82.0",
-        "metro-core": "0.82.0",
-        "metro-file-map": "0.82.0",
-        "metro-resolver": "0.82.0",
-        "metro-runtime": "0.82.0",
-        "metro-source-map": "0.82.0",
-        "metro-symbolicate": "0.82.0",
-        "metro-transform-plugins": "0.82.0",
-        "metro-transform-worker": "0.82.0",
+        "metro-babel-transformer": "0.81.1",
+        "metro-cache": "0.81.1",
+        "metro-cache-key": "0.81.1",
+        "metro-config": "0.81.1",
+        "metro-core": "0.81.1",
+        "metro-file-map": "0.81.1",
+        "metro-resolver": "0.81.1",
+        "metro-runtime": "0.81.1",
+        "metro-source-map": "0.81.1",
+        "metro-symbolicate": "0.81.1",
+        "metro-transform-plugins": "0.81.1",
+        "metro-transform-worker": "0.81.1",
         "mime-types": "^2.1.27",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -9784,9 +9820,9 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.0.tgz",
-      "integrity": "sha512-g+Cic/4M54So7tAuMg278R52UuiXfxXFXN2gfP7OLiATuvbQXyHmmG/zEckLyfPIcBT4i5UEO8PcXFbIgGY5FA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.81.1.tgz",
+      "integrity": "sha512-JECKDrQaUnDmj0x/Q/c8c5YwsatVx38Lu+BfCwX9fR8bWipAzkvJocBpq5rOAJRDXRgDcPv2VO4Q4nFYrpYNQg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -9813,9 +9849,9 @@
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.0.tgz",
-      "integrity": "sha512-CO2ztO54ibCk39C51i32a5+eviZkBzU/IEaF3XJ9CjE7ApFP5epD2v7J1ARMLQyBC1rbx0h2kslV9J2I7ROpZg==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.81.1.tgz",
+      "integrity": "sha512-5fDaHR1yTvpaQuwMAeEoZGsVyvjrkw9IFAS7WixSPvaNY5YfleqoJICPc6hbXFJjvwCCpwmIYFkjqzR/qJ6yqA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -10098,17 +10134,17 @@
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.0.tgz",
-      "integrity": "sha512-6VZD3Zfh2p9xWyjfDn3yE14IyXl2NlVLvhRkmiEz1yb3rWDcNrdGo9UlkwkTPM7eyrPHoYl1gOsaT7hFHNqZiA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.81.1.tgz",
+      "integrity": "sha512-aY72H2ujmRfFxcsbyh83JgqFF+uQ4HFN1VhV2FmcfQG4s1bGKf2Vbkk+vtZ1+EswcBwDZFbkpvAjN49oqwGzAA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^2.2.0",
         "fb-watchman": "^2.0.0",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
+        "jest-worker": "^29.6.3",
         "micromatch": "^4.0.4",
         "nullthrows": "^1.1.1",
         "walker": "^1.0.7"
@@ -10117,10 +10153,25 @@
         "node": ">=18.18"
       }
     },
+    "node_modules/metro-file-map/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/metro-file-map/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/metro-minify-terser": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.0.tgz",
-      "integrity": "sha512-NEbtPAEr9Vemk9Y5gT4hA+Z670n2jBpU1sRSwOEX+uYDie62lNLv/wmkD6CQ6Tykn5T0pPfPV3UFQPYjdMMfFw==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.81.1.tgz",
+      "integrity": "sha512-p/Qz3NNh1nebSqMlxlUALAnESo6heQrnvgHtAuxufRPtKvghnVDq9hGGex8H7z7YYLsqe42PWdt4JxTA3mgkvg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
@@ -10215,9 +10266,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.0.tgz",
-      "integrity": "sha512-jk74Vn+Wvd+QP2HbsA3KgrFRzgWky3UKGnZwAjs7MQgHmfto9tqLNWyQywMmmPTV6f7bCBE6uUOYl9YFI4mUSg==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.81.1.tgz",
+      "integrity": "sha512-7L1lI44/CyjIoBaORhY9fVkoNe8hrzgxjSCQ/lQlcfrV31cZb7u0RGOQrKmUX7Bw4FpejrB70ArQ7Mse9mk7+Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -10232,9 +10283,9 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.0.tgz",
-      "integrity": "sha512-YP1nvSYqEkFF3XNfsj7d+rNuH1syYSG9rqV1nFU1G91ixgZBCZlyLLhVu3fGFTbOZUDHezhlMWs0xFU9r3VTmw==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.81.1.tgz",
+      "integrity": "sha512-M+2hVT3rEy5K7PBmGDgQNq3Zx53TjScOcO/CieyLnCRFtBGWZiSJ2+bLAXXOKyKa/y3bI3i0owxtyxuPGDwbZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -10242,13 +10293,13 @@
         "@babel/parser": "^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.82.0",
-        "metro-babel-transformer": "0.82.0",
-        "metro-cache": "0.82.0",
-        "metro-cache-key": "0.82.0",
-        "metro-minify-terser": "0.82.0",
-        "metro-source-map": "0.82.0",
-        "metro-transform-plugins": "0.82.0",
+        "metro": "0.81.1",
+        "metro-babel-transformer": "0.81.1",
+        "metro-cache": "0.81.1",
+        "metro-cache-key": "0.81.1",
+        "metro-minify-terser": "0.81.1",
+        "metro-source-map": "0.81.1",
+        "metro-transform-plugins": "0.81.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -10256,37 +10307,37 @@
       }
     },
     "node_modules/metro-transform-worker/node_modules/metro-cache": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.0.tgz",
-      "integrity": "sha512-L/XUQTNDXWNwtc7SWGDnaZegHbfF66zsICeKz9qIMcS6+ubKkrYJ8mlsMhTPBEHKmzbenGL/9GnKx5GAqc8i3g==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.81.1.tgz",
+      "integrity": "sha512-Uqcmn6sZ+Y0VJHM88VrG5xCvSeU7RnuvmjPmSOpEcyJJBe02QkfHL05MX2ZyGDTyZdbKCzaX0IijrTe4hN3F0Q==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
-        "metro-core": "0.82.0"
+        "metro-core": "0.81.1"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-transform-worker/node_modules/metro-core": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.0.tgz",
-      "integrity": "sha512-0UeWfwTiXgQd8BnSuXqs7mtXZ6Meu0Zxtef5hWhdA9wh6wieLD2dh3FROGgDgKDlXskvgnYBcD7s7ScANw+/7w==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.81.1.tgz",
+      "integrity": "sha512-4d2/+02IYqOwJs4dmM0dC8hIZqTzgnx2nzN4GTCaXb3Dhtmi/SJ3v6744zZRnithhN4lxf8TTJSHnQV75M7SSA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.82.0"
+        "metro-resolver": "0.81.1"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-transform-worker/node_modules/metro-resolver": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.0.tgz",
-      "integrity": "sha512-t8GS5JwE++vRmHMfj/6TFLFbc2eObJd5G1eDZHRUZreCywGQp9NW3gWSTIxM1iOYU8XpkgKnKZMqdRMQG2gcjA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.81.1.tgz",
+      "integrity": "sha512-E61t6fxRoYRkl6Zo3iUfCKW4DYfum/bLjcejXBMt1y3I7LFkK84TCR/Rs9OAwsMCY/7GOPB4+CREYZOtCC7CNA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -10296,9 +10347,9 @@
       }
     },
     "node_modules/metro-transform-worker/node_modules/metro-source-map": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.0.tgz",
-      "integrity": "sha512-EJR2Fa5bPUFhEJRq1wLkudlVhaWA8WT0AEbyUqJM/VW4woXNEzaNWOt3m3o3JPDIbSK7kyV943b9FTInCYIU9A==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.81.1.tgz",
+      "integrity": "sha512-1i8ROpNNiga43F0ZixAXoFE/SS3RqcRDCCslpynb+ytym0VI7pkTH1woAN2HI9pczYtPrp3Nq0AjRpsuY35ieA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -10306,9 +10357,9 @@
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.82.0",
+        "metro-symbolicate": "0.81.1",
         "nullthrows": "^1.1.1",
-        "ob1": "0.82.0",
+        "ob1": "0.81.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -10317,14 +10368,14 @@
       }
     },
     "node_modules/metro-transform-worker/node_modules/metro-symbolicate": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.0.tgz",
-      "integrity": "sha512-RyrS63AtgwhfHBmeAbW3egRUJ7dkWq48FqXvpjN1/WjofGjKLEPkFTmL9HmLOOIceIEH1q5YnyvI9uKXizSnhA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.81.1.tgz",
+      "integrity": "sha512-Lgk0qjEigtFtsM7C0miXITbcV47E1ZYIfB+m/hCraihiwRWkNUQEPCWvqZmwXKSwVE5mXA0EzQtghAvQSjZDxw==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.82.0",
+        "metro-source-map": "0.81.1",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -10337,9 +10388,9 @@
       }
     },
     "node_modules/metro-transform-worker/node_modules/ob1": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.0.tgz",
-      "integrity": "sha512-1apk2U4j/vpKpKBQw7QyQftL5eOnRdDkK7SKj8QUqRJX8PRuqKLMHknfFRBiX70+/anjkWYvKIiX2vUmvPkvAA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.81.1.tgz",
+      "integrity": "sha512-1PEbvI+AFvOcgdNcO79FtDI1TUO8S3lhiKOyAiyWQF3sFDDKS+aw2/BZvGlArFnSmqckwOOB9chQuIX0/OahoQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -10377,57 +10428,66 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
     },
+    "node_modules/metro/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/metro/node_modules/metro-cache": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.0.tgz",
-      "integrity": "sha512-L/XUQTNDXWNwtc7SWGDnaZegHbfF66zsICeKz9qIMcS6+ubKkrYJ8mlsMhTPBEHKmzbenGL/9GnKx5GAqc8i3g==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.81.1.tgz",
+      "integrity": "sha512-Uqcmn6sZ+Y0VJHM88VrG5xCvSeU7RnuvmjPmSOpEcyJJBe02QkfHL05MX2ZyGDTyZdbKCzaX0IijrTe4hN3F0Q==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
-        "metro-core": "0.82.0"
+        "metro-core": "0.81.1"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro/node_modules/metro-config": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.0.tgz",
-      "integrity": "sha512-CN9y2MM+j/K13tGADUtEyDkVSob+qmG370DApBv/5m0kEEyt8+BW3n+PWTpZcs2XfXNnvj4/+KYMz4ngJsoKlA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.81.1.tgz",
+      "integrity": "sha512-VAAJmxsKIZ+Fz5/z1LVgxa32gE6+2TvrDSSx45g85WoX4EtLmdBGP3DSlpQW3DqFUfNHJCGwMLGXpJnxifd08g==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
-        "jest-validate": "^29.7.0",
-        "metro": "0.82.0",
-        "metro-cache": "0.82.0",
-        "metro-core": "0.82.0",
-        "metro-runtime": "0.82.0"
+        "jest-validate": "^29.6.3",
+        "metro": "0.81.1",
+        "metro-cache": "0.81.1",
+        "metro-core": "0.81.1",
+        "metro-runtime": "0.81.1"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro/node_modules/metro-core": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.0.tgz",
-      "integrity": "sha512-0UeWfwTiXgQd8BnSuXqs7mtXZ6Meu0Zxtef5hWhdA9wh6wieLD2dh3FROGgDgKDlXskvgnYBcD7s7ScANw+/7w==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.81.1.tgz",
+      "integrity": "sha512-4d2/+02IYqOwJs4dmM0dC8hIZqTzgnx2nzN4GTCaXb3Dhtmi/SJ3v6744zZRnithhN4lxf8TTJSHnQV75M7SSA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.82.0"
+        "metro-resolver": "0.81.1"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro/node_modules/metro-resolver": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.0.tgz",
-      "integrity": "sha512-t8GS5JwE++vRmHMfj/6TFLFbc2eObJd5G1eDZHRUZreCywGQp9NW3gWSTIxM1iOYU8XpkgKnKZMqdRMQG2gcjA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.81.1.tgz",
+      "integrity": "sha512-E61t6fxRoYRkl6Zo3iUfCKW4DYfum/bLjcejXBMt1y3I7LFkK84TCR/Rs9OAwsMCY/7GOPB4+CREYZOtCC7CNA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -10437,9 +10497,9 @@
       }
     },
     "node_modules/metro/node_modules/metro-runtime": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.0.tgz",
-      "integrity": "sha512-G7ysHYg0VzAT3R3PTtJd+a9uVfmX5RcHoAxRfCiAp2UTpY+d/pU8TCyaVFiusAKeH5KasexQNzLfwkw2xrDydA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.81.1.tgz",
+      "integrity": "sha512-pqu5j5d01rjF85V/K8SDDJ0NR3dRp6bE3z5bKVVb5O2Rx0nbR9KreUxYALQCRCcQHaYySqCg5fYbGKBHC295YQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -10450,9 +10510,9 @@
       }
     },
     "node_modules/metro/node_modules/metro-source-map": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.0.tgz",
-      "integrity": "sha512-EJR2Fa5bPUFhEJRq1wLkudlVhaWA8WT0AEbyUqJM/VW4woXNEzaNWOt3m3o3JPDIbSK7kyV943b9FTInCYIU9A==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.81.1.tgz",
+      "integrity": "sha512-1i8ROpNNiga43F0ZixAXoFE/SS3RqcRDCCslpynb+ytym0VI7pkTH1woAN2HI9pczYtPrp3Nq0AjRpsuY35ieA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -10460,9 +10520,9 @@
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.82.0",
+        "metro-symbolicate": "0.81.1",
         "nullthrows": "^1.1.1",
-        "ob1": "0.82.0",
+        "ob1": "0.81.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -10471,14 +10531,14 @@
       }
     },
     "node_modules/metro/node_modules/metro-symbolicate": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.0.tgz",
-      "integrity": "sha512-RyrS63AtgwhfHBmeAbW3egRUJ7dkWq48FqXvpjN1/WjofGjKLEPkFTmL9HmLOOIceIEH1q5YnyvI9uKXizSnhA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.81.1.tgz",
+      "integrity": "sha512-Lgk0qjEigtFtsM7C0miXITbcV47E1ZYIfB+m/hCraihiwRWkNUQEPCWvqZmwXKSwVE5mXA0EzQtghAvQSjZDxw==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.82.0",
+        "metro-source-map": "0.81.1",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -10490,10 +10550,16 @@
         "node": ">=18.18"
       }
     },
+    "node_modules/metro/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/metro/node_modules/ob1": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.0.tgz",
-      "integrity": "sha512-1apk2U4j/vpKpKBQw7QyQftL5eOnRdDkK7SKj8QUqRJX8PRuqKLMHknfFRBiX70+/anjkWYvKIiX2vUmvPkvAA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.81.1.tgz",
+      "integrity": "sha512-1PEbvI+AFvOcgdNcO79FtDI1TUO8S3lhiKOyAiyWQF3sFDDKS+aw2/BZvGlArFnSmqckwOOB9chQuIX0/OahoQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "expo-localization": "^16.1.6",
     "expo-location": "^18.0.0",
     "i18n-js": "^4.5.1",
-    "metro": "^0.82.0",
+    "metro": "0.81.1",
     "react": "18.2.0",
     "react-native": "0.74.5",
     "react-native-maps": "1.14.0",

--- a/services/__tests__/logger.test.ts
+++ b/services/__tests__/logger.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync, existsSync, unlinkSync } from 'fs';
+import { log } from '../logger';
+
+describe('log', () => {
+  const logFile = 'data/app.log';
+  afterEach(() => {
+    if (existsSync(logFile)) {
+      unlinkSync(logFile);
+    }
+  });
+
+  it('writes message with level and timestamp', () => {
+    log('INFO', 'hello');
+    const content = readFileSync(logFile, 'utf8');
+    expect(content).toMatch(/INFO hello/);
+  });
+});

--- a/services/logger.ts
+++ b/services/logger.ts
@@ -1,0 +1,19 @@
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+
+const logPath = join('data', 'app.log');
+
+function ensureDir(filePath: string) {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
+
+export function log(level: LogLevel, message: string): void {
+  ensureDir(logPath);
+  const line = `${new Date().toISOString()} ${level} ${message}\n`;
+  appendFileSync(logPath, line);
+}

--- a/services/supabase.js
+++ b/services/supabase.js
@@ -1,5 +1,6 @@
 const { createClient } = require('@supabase/supabase-js');
 const { fetchWithTimeout } = require('./network');
+const { log } = require('./logger');
 
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
@@ -15,6 +16,7 @@ async function fetchLightsAndCycles() {
   } = await supabase.from('lights').select('*');
   if (lightsError) {
     console.error('Error fetching lights:', lightsError);
+    log('ERROR', `Error fetching lights: ${lightsError.message}`);
     return {
       lights: [],
       cycles: [],
@@ -28,6 +30,7 @@ async function fetchLightsAndCycles() {
   } = await supabase.from('light_cycles').select('*');
   if (cyclesError) {
     console.error('Error fetching cycles:', cyclesError);
+    log('ERROR', `Error fetching cycles: ${cyclesError.message}`);
     return {
       lights: lights || [],
       cycles: [],


### PR DESCRIPTION
## Summary
- pin metro to 0.81.1
- write basic logs to data/app.log and use in supabase service
- document HUD maneuver spacing fix in README

## Testing
- `pre-commit run --files package.json package-lock.json services/logger.ts services/supabase.js services/__tests__/logger.test.ts README.md`
- `npm test -- --coverage`
- `timeout 20 npx expo start -c` *(fails: Cannot find module 'metro/src/ModuleGraph/worker/importLocationsPlugin')*

------
https://chatgpt.com/codex/tasks/task_e_68aeb62217ec83239c92a5371d60cf3e