### PR TITLE
refactor: extract navigation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 - Externalized translations into locale files and expanded component test coverage.
 - Refined speed banner recommendation copy.
 - Improved route fetch error handling.
+- Added file logging for diagnostics.
+- Refactored navigation logic into testable helpers.
 
 ## Environment
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,65 @@
+import {
+  handleStartNavigation,
+  handleClearRoute,
+  computeRecommendation,
+} from '../index';
+
+import { Light, LightCycle } from '../domain/types';
+
+describe('navigation helpers', () => {
+  it('tracks start navigation', () => {
+    const track = jest.fn();
+    handleStartNavigation(track);
+    expect(track).toHaveBeenCalledWith('navigation_start');
+  });
+
+  it('returns cleared state', () => {
+    const state = handleClearRoute();
+    expect(state).toEqual({
+      route: null,
+      steps: [],
+      hudInfo: {
+        maneuver: '',
+        distance: 0,
+        street: '',
+        eta: 0,
+        speedLimit: 0,
+      },
+      lightsOnRoute: [],
+      recommended: 0,
+      nearestInfo: { dist: 0, time: 0 },
+      menuVisible: false,
+    });
+  });
+});
+
+describe('computeRecommendation', () => {
+  const light: Light = {
+    id: 'l1',
+    name: 'L1',
+    lat: 0,
+    lon: 0,
+    direction: 'MAIN',
+  };
+  const cycle: LightCycle = {
+    id: 'c1',
+    light_id: 'l1',
+    cycle_seconds: 60,
+    t0_iso: new Date(0).toISOString(),
+    main_green: [30, 40],
+    secondary_green: [0, 10],
+    ped_green: [10, 20],
+  };
+
+  it('calculates speed and nearest info', () => {
+    const { recommended, nearestInfo } = computeRecommendation(
+      [{ light, cycle, dist_m: 500, dirForDriver: 'MAIN' }],
+      { speed: 50 / 3.6 },
+      0,
+      0,
+    );
+    expect(recommended).toBeGreaterThanOrEqual(47);
+    expect(recommended).toBeLessThanOrEqual(56);
+    expect(nearestInfo.dist).toBe(500);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,57 @@
+import { pickSpeed, applyHysteresis } from './domain/advisor';
+import { getGreenWindow } from './domain/phases';
+
+export const handleStartNavigation = (
+  track: (event: string) => void,
+): void => {
+  track('navigation_start');
+};
+
+export const handleClearRoute = () => ({
+  route: null as any,
+  steps: [] as any[],
+  hudInfo: {
+    maneuver: '',
+    distance: 0,
+    street: '',
+    eta: 0,
+    speedLimit: 0,
+  },
+  lightsOnRoute: [] as any[],
+  recommended: 0,
+  nearestInfo: { dist: 0, time: 0 },
+  menuVisible: false,
+});
+
+export function computeRecommendation(
+  lightsOnRoute: {
+    light: any;
+    cycle: any;
+    dist_m: number;
+    dirForDriver: any;
+  }[],
+  car: { speed: number },
+  nowSec: number,
+  prevRecommended: number,
+) {
+  const res = pickSpeed(nowSec, lightsOnRoute, car.speed * 3.6);
+  const nearest = lightsOnRoute[0];
+  let nearestInfo = { dist: 0, time: 0 };
+  let nearestStillGreen = false;
+  if (nearest && nearest.cycle) {
+    const cycleLen = nearest.cycle.cycle_seconds;
+    const t0 = Date.parse(nearest.cycle.t0_iso) / 1000;
+    const eta = nowSec + nearest.dist_m / ((res.recommended * 1000) / 3600);
+    const phase = (((eta - t0) % cycleLen) + cycleLen) % cycleLen;
+    const [gs, ge] = getGreenWindow(nearest.cycle, nearest.dirForDriver);
+    nearestStillGreen = phase >= gs + 2 && phase <= ge - 2;
+    let timeToWindow = 0;
+    if (phase < gs) timeToWindow = gs - phase;
+    else if (phase > ge) timeToWindow = cycleLen - phase + gs;
+    nearestInfo = { dist: nearest.dist_m, time: timeToWindow };
+  }
+  const recommended = prevRecommended
+    ? applyHysteresis(prevRecommended, res.recommended, nearestStillGreen)
+    : res.recommended;
+  return { recommended, nearestInfo };
+}


### PR DESCRIPTION
## Summary
- move navigation handlers and speed calculation to pure functions
- wire App.js to new helpers
- cover navigation helpers with unit tests

## Testing
- `npx eslint src --format unix` *(fails: ESLint couldn't find a config)*
- `pre-commit run --files App.js src/index.ts src/__tests__/index.test.ts` *(fails: pre-commit not installed)*
- `npm test -- --coverage` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeba806c008323ae3c3879e6b67227