### PR TITLE
chore: add cached test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: 'npm'
       - run: npm ci
       - run: npm test -- --coverage
       - uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary
- cache npm dependencies in CI test job
- run tests with coverage and upload to Codecov

## Testing
- `pre-commit run --files .github/workflows/test.yml` *(fails: command not found)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aebba92c108323b01ac8739ba496e9