### PR TITLE
refactor: add service interfaces

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,16 +14,12 @@ import LightFormModal from './components/LightFormModal';
 import CycleFormModal from './components/CycleFormModal';
 import SpeedBanner from './components/SpeedBanner';
 import MainMenu from './components/MainMenu';
-import {
-  fetchLightsAndCycles,
-  subscribeLightCycles,
-  supabase,
-} from './services/supabase';
+import { supabaseService, supabase } from './services/supabase';
 import { getRoute, RouteStep } from './services/ors';
 import i18n from './src/i18n';
 import { mapColorForRuntime } from './src/domain/phases';
 import { projectLightsToRoute } from './src/domain/matching';
-import { trackEvent } from './services/analytics';
+import { analytics } from './services/analytics';
 import {
   handleStartNavigation as startNavigation,
   handleClearRoute as clearRoute,
@@ -68,7 +64,7 @@ export default function App(): JSX.Element {
   const [menuVisible, setMenuVisible] = useState<boolean>(false);
 
   const onStartNavigation = () => {
-    startNavigation(trackEvent);
+    startNavigation(analytics.trackEvent);
     setMenuVisible(false);
   };
 
@@ -90,12 +86,12 @@ export default function App(): JSX.Element {
   };
 
   const handleSettings = () => {
-    trackEvent('settings_change');
+    analytics.trackEvent('settings_change');
     setMenuVisible(false);
   };
 
   useEffect(() => {
-    fetchLightsAndCycles().then(({ lights, cycles, error }) => {
+    supabaseService.fetchLightsAndCycles().then(({ lights, cycles, error }) => {
       if (error) {
         setLoadError('Failed to load data');
         return;
@@ -105,7 +101,7 @@ export default function App(): JSX.Element {
       for (const c of cycles) map[c.light_id] = c;
       setCycles(map);
     });
-    const sub = subscribeLightCycles((cycle) => {
+    const sub = supabaseService.subscribeLightCycles((cycle) => {
       setCycles((c) => ({ ...c, [cycle.light_id]: cycle }));
     });
     return () => {
@@ -174,7 +170,7 @@ export default function App(): JSX.Element {
       .select()
       .single();
     if (!error) {
-      trackEvent('light_added', { id: inserted.id });
+      analytics.trackEvent('light_added', { id: inserted.id });
       setLights((l) => [...l, inserted as Light]);
       setLightModal(null);
       setCycleModal({ light_id: inserted.id });

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 - Refactored navigation logic into testable helpers.
 - Added GitHub Actions workflow for cached tests.
 - Configured ESLint and Prettier for consistent formatting.
+- Converted remaining JavaScript files to TypeScript.
+- Introduced typed interfaces for analytics, network, and Supabase services.
 
 ## Environment
 

--- a/services/__tests__/network.test.ts
+++ b/services/__tests__/network.test.ts
@@ -1,4 +1,6 @@
-import { fetchWithTimeout } from '../network';
+import { network } from '../network';
+
+const { fetchWithTimeout } = network;
 
 describe('fetchWithTimeout', () => {
   const originalFetch = global.fetch;

--- a/services/analytics.ts
+++ b/services/analytics.ts
@@ -1,13 +1,15 @@
 import * as Analytics from 'expo-firebase-analytics';
 import { log } from './logger';
+import type { Analytics as AnalyticsInterface } from '../src/interfaces/analytics';
 
-export async function trackEvent(
-  name: string,
-  params?: Record<string, unknown>,
-): Promise<void> {
-  try {
-    await Analytics.logEvent(name, params);
-  } catch (err) {
-    await log('WARN', `Failed to log analytics event: ${String(err)}`);
-  }
-}
+export const analytics: AnalyticsInterface = {
+  async trackEvent(name, params) {
+    try {
+      await Analytics.logEvent(name, params);
+    } catch (err) {
+      await log('WARN', `Failed to log analytics event: ${String(err)}`);
+    }
+  },
+};
+
+export const trackEvent = analytics.trackEvent;

--- a/services/network.ts
+++ b/services/network.ts
@@ -1,38 +1,37 @@
-export interface FetchOptions extends RequestInit {
-  timeout?: number;
-}
+import type { Network, FetchOptions } from '../src/interfaces/network';
 
-export async function fetchWithTimeout(
-  input: RequestInfo | URL,
-  options: FetchOptions = {}
-): Promise<Response> {
-  const { timeout = 10000, ...init } = options;
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  try {
-    const res = await fetch(input, { ...init, signal: controller.signal });
-    if (!res.ok) {
-      let message = '';
-      try {
-        const data = await res.json();
-        message = data.message || JSON.stringify(data);
-      } catch {
+export const network: Network = {
+  async fetchWithTimeout(input, options = {}) {
+    const { timeout = 10000, ...init } = options;
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), timeout);
+    try {
+      const res = await fetch(input, { ...init, signal: controller.signal });
+      if (!res.ok) {
+        let message = '';
         try {
-          message = await res.text();
+          const data = await res.json();
+          message = data.message || JSON.stringify(data);
         } catch {
-          /* ignore */
+          try {
+            message = await res.text();
+          } catch {
+            /* ignore */
+          }
         }
+        message = message || res.statusText || 'Unknown error';
+        throw new Error(`Request failed with status ${res.status}: ${message}`);
       }
-      message = message || res.statusText || 'Unknown error';
-      throw new Error(`Request failed with status ${res.status}: ${message}`);
+      return res;
+    } catch (err: any) {
+      if (err.name === 'AbortError') {
+        throw new Error('Request timed out. Please try again.');
+      }
+      throw new Error(err.message || 'Network request failed.');
+    } finally {
+      clearTimeout(id);
     }
-    return res;
-  } catch (err: any) {
-    if (err.name === 'AbortError') {
-      throw new Error('Request timed out. Please try again.');
-    }
-    throw new Error(err.message || 'Network request failed.');
-  } finally {
-    clearTimeout(id);
-  }
-}
+  },
+};
+
+export const fetchWithTimeout = network.fetchWithTimeout;

--- a/services/ors.ts
+++ b/services/ors.ts
@@ -1,4 +1,4 @@
-import { fetchWithTimeout } from './network';
+import { network } from './network';
 
 export interface LatLng {
   latitude: number;
@@ -33,7 +33,7 @@ export async function getRoute(
 
   let res: Response;
   try {
-    res = await fetchWithTimeout(url, {
+    res = await network.fetchWithTimeout(url, {
       headers: { Authorization: apiKey },
     });
   } catch (err) {

--- a/services/supabase.ts
+++ b/services/supabase.ts
@@ -4,9 +4,10 @@ import {
   RealtimeChannel,
   RealtimePostgresChangesPayload,
 } from '@supabase/supabase-js';
-import { fetchWithTimeout } from './network';
+import { network } from './network';
 import { log } from './logger';
 import type { Light, LightCycle } from '../src/domain/types';
+import type { Supabase as SupabaseInterface } from '../src/interfaces/supabase';
 
 const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
 const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '';
@@ -15,11 +16,11 @@ export const supabase: SupabaseClient = createClient(
   SUPABASE_URL,
   SUPABASE_ANON_KEY,
   {
-    global: { fetch: fetchWithTimeout },
+    global: { fetch: network.fetchWithTimeout },
   },
 );
 
-export async function fetchLightsAndCycles(): Promise<{
+async function fetchLightsAndCycles(): Promise<{
   lights: Light[];
   cycles: LightCycle[];
   error: Error | null;
@@ -55,9 +56,7 @@ export async function fetchLightsAndCycles(): Promise<{
   };
 }
 
-export function subscribeLightCycles(
-  cb: (cycle: LightCycle) => void,
-): RealtimeChannel {
+function subscribeLightCycles(cb: (cycle: LightCycle) => void): RealtimeChannel {
   return supabase
     .channel('public:light_cycles')
     .on(
@@ -68,3 +67,8 @@ export function subscribeLightCycles(
     )
     .subscribe();
 }
+
+export const supabaseService: SupabaseInterface = {
+  fetchLightsAndCycles,
+  subscribeLightCycles,
+};

--- a/src/interfaces/analytics.ts
+++ b/src/interfaces/analytics.ts
@@ -1,0 +1,3 @@
+export interface Analytics {
+  trackEvent(name: string, params?: Record<string, unknown>): Promise<void>;
+}

--- a/src/interfaces/network.ts
+++ b/src/interfaces/network.ts
@@ -1,0 +1,10 @@
+export interface FetchOptions extends RequestInit {
+  timeout?: number;
+}
+
+export interface Network {
+  fetchWithTimeout(
+    input: RequestInfo | URL,
+    options?: FetchOptions,
+  ): Promise<Response>;
+}

--- a/src/interfaces/supabase.ts
+++ b/src/interfaces/supabase.ts
@@ -1,0 +1,11 @@
+import type { Light, LightCycle } from '../domain/types';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+export interface Supabase {
+  fetchLightsAndCycles(): Promise<{
+    lights: Light[];
+    cycles: LightCycle[];
+    error: Error | null;
+  }>;
+  subscribeLightCycles(cb: (cycle: LightCycle) => void): RealtimeChannel;
+}

--- a/src/supabase.test.ts
+++ b/src/supabase.test.ts
@@ -20,9 +20,10 @@ describe('fetchLightsAndCycles error handling', () => {
   it('returns error when fetching lights fails', async () => {
     const logger = await import('../services/logger');
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue(undefined);
-    const { fetchLightsAndCycles, supabase } = await import(
+    const { supabaseService, supabase } = await import(
       '../services/supabase'
     );
+    const { fetchLightsAndCycles } = supabaseService;
     const originalFrom = supabase.from;
 
     supabase.from = jest.fn().mockReturnValue({
@@ -44,9 +45,10 @@ describe('fetchLightsAndCycles error handling', () => {
   it('returns error when fetching cycles fails', async () => {
     const logger = await import('../services/logger');
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue(undefined);
-    const { fetchLightsAndCycles, supabase } = await import(
+    const { supabaseService, supabase } = await import(
       '../services/supabase'
     );
+    const { fetchLightsAndCycles } = supabaseService;
     const originalFrom = supabase.from;
 
     supabase.from = jest


### PR DESCRIPTION
## Summary
- define minimal analytics, network and supabase interfaces
- refactor services to implement typed contracts
- update imports, tests and docs

## Testing
- `pre-commit run --files src/interfaces/analytics.ts src/interfaces/network.ts src/interfaces/supabase.ts services/analytics.ts services/network.ts services/supabase.ts services/ors.ts services/__tests__/network.test.ts src/supabase.test.ts App.tsx README.md`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aed0419b7083238720adb5dfb1fc84