### PR TITLE
feat: cache route for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Minimal React Native (Expo) client showing a map with a car marker and driving H
 
 ## Recent changes
 
+- Added offline route caching to reuse the last fetched route when connectivity fails.
 - Consolidated project structure by moving `components/` and `services/` into `src/`.
 - Fixed HUD maneuver spacing.
 - Updated localization string spacing.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import {
   handleClearRoute,
   computeRecommendation,
   getNearestInfo,
+  initialState,
 } from '../index';
 
 import { Light, LightCycle } from '../domain/types';
@@ -16,21 +17,8 @@ describe('navigation helpers', () => {
 
   it('returns cleared state', () => {
     const state = handleClearRoute();
-    expect(state).toEqual({
-      route: null,
-      steps: [],
-      hudInfo: {
-        maneuver: '',
-        distance: 0,
-        street: '',
-        eta: 0,
-        speedLimit: 0,
-      },
-      lightsOnRoute: [],
-      recommended: 0,
-      nearestInfo: { dist: 0, time: 0 },
-      menuVisible: false,
-    });
+    expect(state).toEqual(initialState);
+    expect(state).not.toBe(initialState);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,25 @@ export const handleStartNavigation = (track: (event: string) => void): void => {
   track('navigation_start');
 };
 
-export const handleClearRoute = () => ({
-  route: null as unknown,
-  steps: [] as unknown[],
+export interface NavigationState {
+  route: unknown;
+  steps: unknown[];
+  hudInfo: {
+    maneuver: string;
+    distance: number;
+    street: string;
+    eta: number;
+    speedLimit: number;
+  };
+  lightsOnRoute: LightOnRoute[];
+  recommended: number;
+  nearestInfo: { dist: number; time: number };
+  menuVisible: boolean;
+}
+
+export const initialState: NavigationState = {
+  route: null,
+  steps: [],
   hudInfo: {
     maneuver: '',
     distance: 0,
@@ -16,10 +32,17 @@ export const handleClearRoute = () => ({
     eta: 0,
     speedLimit: 0,
   },
-  lightsOnRoute: [] as LightOnRoute[],
+  lightsOnRoute: [],
   recommended: 0,
   nearestInfo: { dist: 0, time: 0 },
   menuVisible: false,
+};
+
+export const handleClearRoute = (): NavigationState => ({
+  ...initialState,
+  hudInfo: { ...initialState.hudInfo },
+  lightsOnRoute: [],
+  nearestInfo: { ...initialState.nearestInfo },
 });
 
 export interface LightOnRoute {

--- a/src/services/routeCache.test.ts
+++ b/src/services/routeCache.test.ts
@@ -1,0 +1,32 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { RouteResult } from './ors';
+import { saveRoute, loadRoute } from './routeCache';
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('@react-native-async-storage/async-storage/jest/async-storage-mock');
+});
+
+const route: RouteResult = {
+  geometry: [{ latitude: 1, longitude: 2 }],
+  distance: 1,
+  duration: 1,
+  steps: [],
+};
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('routeCache', () => {
+  it('saves and loads route', async () => {
+    await saveRoute(route);
+    const loaded = await loadRoute();
+    expect(loaded).toEqual(route);
+  });
+
+  it('returns null when empty', async () => {
+    const loaded = await loadRoute();
+    expect(loaded).toBeNull();
+  });
+});

--- a/src/services/routeCache.ts
+++ b/src/services/routeCache.ts
@@ -1,0 +1,18 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { RouteResult } from './ors';
+
+const KEY = 'current_route';
+
+export async function loadRoute(): Promise<RouteResult | null> {
+  const json = await AsyncStorage.getItem(KEY);
+  if (!json) return null;
+  try {
+    return JSON.parse(json) as RouteResult;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveRoute(route: RouteResult): Promise<void> {
+  await AsyncStorage.setItem(KEY, JSON.stringify(route));
+}


### PR DESCRIPTION
## Summary
- add AsyncStorage route cache service
- load cached route on startup when network fails
- persist route after successful fetch
- refactor navigation helpers for testability
- document offline route caching in README

## Testing
- `pre-commit run --files App.tsx src/services/routeCache.ts src/services/routeCache.test.ts src/index.ts src/__tests__/index.test.ts README.md`
- `npx eslint App.tsx src/services/routeCache.ts src/services/routeCache.test.ts src/index.ts src/__tests__/index.test.ts`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aed9ca7edc8323b3393b431ec3bdf2