### PR TITLE
fix: add space in Russian HUD translation

### DIFF
--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -22,7 +22,7 @@
     }
   },
   "hud": {
-    "maneuver": "%{maneuver} через %{distance}м",
+    "maneuver": "%{maneuver} через %{distance} м",
     "speed": "Скорость: %{speed}",
     "limit": "Лимит: %{limit}",
     "eta": "ETA: %{eta}с"


### PR DESCRIPTION
## Summary
- correct spacing in Russian maneuver HUD string

## Testing
- `pre-commit run --files src/locales/ru.json`
- `npm run lint` *(fails: 143 problems)*
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68aedbfac5d8832394cecb69875df708