### PR TITLE
feat: track traffic light phase durations

### DIFF
--- a/src/services/__tests__/colorPhases.test.ts
+++ b/src/services/__tests__/colorPhases.test.ts
@@ -1,0 +1,25 @@
+import { finalizePhase, ColorPhase } from '../colorPhases';
+
+describe('finalizePhase', () => {
+  it('records duration using start time', () => {
+    const phases: ColorPhase[] = [];
+    let current = 'red';
+    let start = 0;
+
+    finalizePhase(phases, current, start, 1000); // switch to green at 1s
+    current = 'green';
+    start = 1000;
+
+    finalizePhase(phases, current, start, 2500); // switch to yellow at 2.5s
+    current = 'yellow';
+    start = 2500;
+
+    finalizePhase(phases, current, start, 4000); // stop at 4s
+
+    expect(phases).toEqual([
+      { color: 'red', duration: 1000 },
+      { color: 'green', duration: 1500 },
+      { color: 'yellow', duration: 1500 },
+    ]);
+  });
+});

--- a/src/services/colorPhases.ts
+++ b/src/services/colorPhases.ts
@@ -1,0 +1,15 @@
+export interface ColorPhase {
+  color: string;
+  duration: number;
+}
+
+export function finalizePhase(
+  phases: ColorPhase[],
+  currentColor: string | null,
+  startTime: number | null,
+  now: number,
+): void {
+  if (currentColor && startTime !== null) {
+    phases.push({ color: currentColor, duration: now - startTime });
+  }
+}


### PR DESCRIPTION
## Summary
- compute phase durations on color changes using `colorStartTime`
- reset phase tracking on start/stop
- add helper and tests for phase duration calculation

## Testing
- `pre-commit run --files src/components/CameraScreen.tsx src/services/colorPhases.ts src/services/__tests__/colorPhases.test.ts`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aede58fa008323a33754cf36080ce7