### PR TITLE
test: ensure fetchWithTimeout handles headers and abort

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Tracked traffic light phase durations for analytics.
 - Added offline route caching to reuse the last fetched route when connectivity fails.
 - Consolidated project structure by moving `components/` and `services/` into `src/`.
 - Fixed HUD maneuver spacing.

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+Guidelines for code in `src/services`.
+
+- Provide small, focused helpers for networking, logging, and analytics.
+- Export typed interfaces from `src/interfaces` where possible.
+- Place service tests in `__tests__/` beside the code.
+- Mock `fetch` and external APIs in tests; avoid real network calls.
+- Run `pre-commit run --files <files>` and `npm test -- --coverage` after changes.


### PR DESCRIPTION
## Summary
- test(fetchWithTimeout): verify custom headers are forwarded and timeout aborts the request
- docs: outline service guidelines and note traffic light phase tracking

## Testing
- `pre-commit run --files src/services/__tests__/network.test.ts README.md src/services/AGENTS.md`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aee1c40ec08323b00daf095f4fa2e3