### PR TITLE
fix: correct main direction color

### DIFF
--- a/src/domain/__tests__/phases.test.ts
+++ b/src/domain/__tests__/phases.test.ts
@@ -20,10 +20,17 @@ describe('phases utilities', () => {
 
   it('mapColorForRuntime picks colors by phase', () => {
     const t0 = Date.parse(cycle.t0_iso) / 1000;
-    expect(mapColorForRuntime(cycle, 'MAIN', t0 + 5)).toBe('red');
+    expect(mapColorForRuntime(cycle, 'MAIN', t0 + 5)).toBe('green');
     expect(mapColorForRuntime(cycle, 'SECONDARY', t0 + 15)).toBe('green');
     expect(mapColorForRuntime(cycle, 'PEDESTRIAN', t0 + 25)).toBe('blue');
     expect(mapColorForRuntime(cycle, 'MAIN', t0 + 35)).toBe('gray');
     expect(mapColorForRuntime(null, 'MAIN', t0 + 5)).toBe('gray');
+  });
+
+  it('mapColorForRuntime returns gray outside green windows for all directions', () => {
+    const t0 = Date.parse(cycle.t0_iso) / 1000;
+    expect(mapColorForRuntime(cycle, 'MAIN', t0 + 15)).toBe('gray');
+    expect(mapColorForRuntime(cycle, 'SECONDARY', t0 + 25)).toBe('gray');
+    expect(mapColorForRuntime(cycle, 'PEDESTRIAN', t0 + 5)).toBe('gray');
   });
 });

--- a/src/domain/phases.ts
+++ b/src/domain/phases.ts
@@ -1,6 +1,9 @@
 import { Direction, LightCycle } from './types';
 
-export function getGreenWindow(c: LightCycle, dir: Direction): [number, number] {
+export function getGreenWindow(
+  c: LightCycle,
+  dir: Direction,
+): [number, number] {
   if (dir === 'MAIN') return [c.main_green[0], c.main_green[1]];
   if (dir === 'SECONDARY') return [c.secondary_green[0], c.secondary_green[1]];
   return [c.ped_green[0], c.ped_green[1]];
@@ -9,16 +12,16 @@ export function getGreenWindow(c: LightCycle, dir: Direction): [number, number] 
 export function mapColorForRuntime(
   cycle: LightCycle | null,
   dir: Direction,
-  nowSec: number
+  nowSec: number,
 ) {
   if (!cycle) return 'gray';
   const cycleLen = cycle.cycle_seconds;
   const t0 = Date.parse(cycle.t0_iso) / 1000;
-  const phase = ((nowSec - t0) % cycleLen + cycleLen) % cycleLen;
+  const phase = (((nowSec - t0) % cycleLen) + cycleLen) % cycleLen;
   const [gs, ge] = getGreenWindow(cycle, dir);
   const isGreen = phase >= gs && phase <= ge;
   if (dir === 'PEDESTRIAN') return isGreen ? 'blue' : 'gray';
   if (dir === 'SECONDARY') return isGreen ? 'green' : 'gray';
-  if (dir === 'MAIN') return isGreen ? 'red' : 'gray';
+  if (dir === 'MAIN') return isGreen ? 'green' : 'gray';
   return 'gray';
 }


### PR DESCRIPTION
## Summary
- show green for main direction when phase is active
- cover all directions with color mapping tests

## Testing
- `pre-commit run --files src/domain/phases.ts src/domain/__tests__/phases.test.ts`
- `npx eslint src/domain/phases.ts src/domain/__tests__/phases.test.ts`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aeed9edf9c83239243359e9a5226b1