### PR TITLE
test: handle zero recommended speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Handled zero recommended speed to avoid divide-by-zero in nearest info calculation.
 - Tracked traffic light phase durations for analytics.
 - Added offline route caching to reuse the last fetched route when connectivity fails.
 - Consolidated project structure by moving `components/` and `services/` into `src/`.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -61,4 +61,14 @@ describe('computeRecommendation', () => {
     expect(nearestInfo.dist).toBe(500);
     expect(typeof nearestStillGreen).toBe('boolean');
   });
+
+  it('handles zero recommended speed', () => {
+    const { nearestInfo, nearestStillGreen } = getNearestInfo(
+      { light, cycle, dist_m: 500, dirForDriver: 'MAIN' },
+      0,
+      0,
+    );
+    expect(nearestInfo).toEqual({ dist: 0, time: 0 });
+    expect(nearestStillGreen).toBe(false);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function getNearestInfo(
 ) {
   let nearestInfo = { dist: 0, time: 0 };
   let nearestStillGreen = false;
-  if (nearest) {
+  if (nearest && recommended > 0) {
     const cycleLen = nearest.cycle.cycle_seconds;
     const t0 = Date.parse(nearest.cycle.t0_iso) / 1000;
     const eta = nowSec + nearest.dist_m / ((recommended * 1000) / 3600);


### PR DESCRIPTION
## Summary
- avoid divide-by-zero when recommended speed is non-positive
- test nearest info returns zeroes for zero recommended speed
- document nearest info fix in README

## Testing
- `pre-commit run --files README.md src/index.ts src/__tests__/index.test.ts`
- `npx eslint -c .eslintrc.cjs src --format unix` *(fails: files ignored)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aef2cb3c2883239d9fd085c27ba7a0