### PR TITLE
refactor: modularize navigation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Modularized navigation helpers for easier testing and reuse.
 - Handled zero recommended speed to avoid divide-by-zero in nearest info calculation.
 - Tracked traffic light phase durations for analytics.
 - Added offline route caching to reuse the last fetched route when connectivity fails.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,12 +1,4 @@
-import {
-  handleStartNavigation,
-  handleClearRoute,
-  computeRecommendation,
-  getNearestInfo,
-  initialState,
-} from '../index';
-
-import { Light, LightCycle } from '../domain/types';
+import { handleStartNavigation, handleClearRoute, initialState } from '../index';
 
 describe('navigation helpers', () => {
   it('tracks start navigation', () => {
@@ -19,56 +11,5 @@ describe('navigation helpers', () => {
     const state = handleClearRoute();
     expect(state).toEqual(initialState);
     expect(state).not.toBe(initialState);
-  });
-});
-
-describe('computeRecommendation', () => {
-  const light: Light = {
-    id: 'l1',
-    name: 'L1',
-    lat: 0,
-    lon: 0,
-    direction: 'MAIN',
-  };
-  const cycle: LightCycle = {
-    id: 'c1',
-    light_id: 'l1',
-    cycle_seconds: 60,
-    t0_iso: new Date(0).toISOString(),
-    main_green: [30, 40],
-    secondary_green: [0, 10],
-    ped_green: [10, 20],
-  };
-
-  it('calculates speed and nearest info', () => {
-    const { recommended, nearestInfo } = computeRecommendation(
-      [{ light, cycle, dist_m: 500, dirForDriver: 'MAIN' }],
-      { speed: 50 / 3.6 },
-      0,
-      0,
-    );
-    expect(recommended).toBeGreaterThanOrEqual(47);
-    expect(recommended).toBeLessThanOrEqual(56);
-    expect(nearestInfo.dist).toBe(500);
-  });
-
-  it('computes nearest info separately', () => {
-    const { nearestInfo, nearestStillGreen } = getNearestInfo(
-      { light, cycle, dist_m: 500, dirForDriver: 'MAIN' },
-      50,
-      0,
-    );
-    expect(nearestInfo.dist).toBe(500);
-    expect(typeof nearestStillGreen).toBe('boolean');
-  });
-
-  it('handles zero recommended speed', () => {
-    const { nearestInfo, nearestStillGreen } = getNearestInfo(
-      { light, cycle, dist_m: 500, dirForDriver: 'MAIN' },
-      0,
-      0,
-    );
-    expect(nearestInfo).toEqual({ dist: 0, time: 0 });
-    expect(nearestStillGreen).toBe(false);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { pickSpeed, applyHysteresis } from './domain/advisor';
-import { getGreenWindow } from './domain/phases';
 import type { Direction, Light, LightCycle } from './domain/types';
 
 export const handleStartNavigation = (track: (event: string) => void): void => {
@@ -52,42 +50,5 @@ export interface LightOnRoute {
   dirForDriver: Direction;
 }
 
-export function getNearestInfo(
-  nearest: LightOnRoute | undefined,
-  recommended: number,
-  nowSec: number,
-) {
-  let nearestInfo = { dist: 0, time: 0 };
-  let nearestStillGreen = false;
-  if (nearest && recommended > 0) {
-    const cycleLen = nearest.cycle.cycle_seconds;
-    const t0 = Date.parse(nearest.cycle.t0_iso) / 1000;
-    const eta = nowSec + nearest.dist_m / ((recommended * 1000) / 3600);
-    const phase = (((eta - t0) % cycleLen) + cycleLen) % cycleLen;
-    const [gs, ge] = getGreenWindow(nearest.cycle, nearest.dirForDriver);
-    nearestStillGreen = phase >= gs + 2 && phase <= ge - 2;
-    let timeToWindow = 0;
-    if (phase < gs) timeToWindow = gs - phase;
-    else if (phase > ge) timeToWindow = cycleLen - phase + gs;
-    nearestInfo = { dist: nearest.dist_m, time: timeToWindow };
-  }
-  return { nearestInfo, nearestStillGreen };
-}
-
-export function computeRecommendation(
-  lightsOnRoute: LightOnRoute[],
-  car: { speed: number },
-  nowSec: number,
-  prevRecommended: number,
-) {
-  const res = pickSpeed(nowSec, lightsOnRoute, car.speed * 3.6);
-  const { nearestInfo, nearestStillGreen } = getNearestInfo(
-    lightsOnRoute[0],
-    res.recommended,
-    nowSec,
-  );
-  const recommended = prevRecommended
-    ? applyHysteresis(prevRecommended, res.recommended, nearestStillGreen)
-    : res.recommended;
-  return { recommended, nearestInfo };
-}
+export { getNearestInfo } from './navigation/getNearestInfo';
+export { computeRecommendation } from './navigation/computeRecommendation';

--- a/src/navigation/AGENTS.md
+++ b/src/navigation/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+Guidelines for navigation helpers.
+
+- Keep functions pure and free of side effects.
+- Place tests next to the helpers they cover.
+- After changes run:
+  ```bash
+  pre-commit run --files <files>
+  npm test -- --coverage
+  ```

--- a/src/navigation/computeRecommendation.test.ts
+++ b/src/navigation/computeRecommendation.test.ts
@@ -1,0 +1,43 @@
+import { computeRecommendation } from './computeRecommendation';
+import type { Light, LightCycle } from '../domain/types';
+
+const light: Light = {
+  id: 'l1',
+  name: 'L1',
+  lat: 0,
+  lon: 0,
+  direction: 'MAIN',
+};
+const cycle: LightCycle = {
+  id: 'c1',
+  light_id: 'l1',
+  cycle_seconds: 60,
+  t0_iso: new Date(0).toISOString(),
+  main_green: [30, 40],
+  secondary_green: [0, 10],
+  ped_green: [10, 20],
+};
+
+describe('computeRecommendation', () => {
+  it('calculates speed and nearest info', () => {
+    const { recommended, nearestInfo } = computeRecommendation(
+      [{ light, cycle, dist_m: 500, dirForDriver: 'MAIN' }],
+      { speed: 50 / 3.6 },
+      0,
+      0,
+    );
+    expect(recommended).toBeGreaterThanOrEqual(47);
+    expect(recommended).toBeLessThanOrEqual(56);
+    expect(nearestInfo.dist).toBe(500);
+  });
+
+  it('applies hysteresis when light stays green', () => {
+    const { recommended } = computeRecommendation(
+      [{ light, cycle, dist_m: 500, dirForDriver: 'MAIN' }],
+      { speed: 50 / 3.6 },
+      0,
+      52,
+    );
+    expect(recommended).toBe(52);
+  });
+});

--- a/src/navigation/computeRecommendation.ts
+++ b/src/navigation/computeRecommendation.ts
@@ -1,0 +1,21 @@
+import { pickSpeed, applyHysteresis } from '../domain/advisor';
+import { getNearestInfo } from './getNearestInfo';
+import type { LightOnRoute } from '../index';
+
+export function computeRecommendation(
+  lightsOnRoute: LightOnRoute[],
+  car: { speed: number },
+  nowSec: number,
+  prevRecommended: number,
+) {
+  const res = pickSpeed(nowSec, lightsOnRoute, car.speed * 3.6);
+  const { nearestInfo, nearestStillGreen } = getNearestInfo(
+    lightsOnRoute[0],
+    res.recommended,
+    nowSec,
+  );
+  const recommended = prevRecommended
+    ? applyHysteresis(prevRecommended, res.recommended, nearestStillGreen)
+    : res.recommended;
+  return { recommended, nearestInfo };
+}

--- a/src/navigation/getNearestInfo.test.ts
+++ b/src/navigation/getNearestInfo.test.ts
@@ -1,0 +1,50 @@
+import { getNearestInfo } from './getNearestInfo';
+import type { Light, LightCycle } from '../domain/types';
+
+const light: Light = {
+  id: 'l1',
+  name: 'L1',
+  lat: 0,
+  lon: 0,
+  direction: 'MAIN',
+};
+const cycle: LightCycle = {
+  id: 'c1',
+  light_id: 'l1',
+  cycle_seconds: 60,
+  t0_iso: new Date(0).toISOString(),
+  main_green: [30, 40],
+  secondary_green: [0, 10],
+  ped_green: [10, 20],
+};
+
+describe('getNearestInfo', () => {
+  it('computes nearest info', () => {
+    const { nearestInfo, nearestStillGreen } = getNearestInfo(
+      { light, cycle, dist_m: 500, dirForDriver: 'MAIN' },
+      50,
+      0,
+    );
+    expect(nearestInfo.dist).toBe(500);
+    expect(typeof nearestStillGreen).toBe('boolean');
+  });
+
+  it('detects when nearest is still green', () => {
+    const { nearestStillGreen } = getNearestInfo(
+      { light, cycle, dist_m: 500, dirForDriver: 'MAIN' },
+      50,
+      0,
+    );
+    expect(nearestStillGreen).toBe(true);
+  });
+
+  it('handles zero recommended speed', () => {
+    const { nearestInfo, nearestStillGreen } = getNearestInfo(
+      { light, cycle, dist_m: 500, dirForDriver: 'MAIN' },
+      0,
+      0,
+    );
+    expect(nearestInfo).toEqual({ dist: 0, time: 0 });
+    expect(nearestStillGreen).toBe(false);
+  });
+});

--- a/src/navigation/getNearestInfo.ts
+++ b/src/navigation/getNearestInfo.ts
@@ -1,0 +1,24 @@
+import { getGreenWindow } from '../domain/phases';
+import type { LightOnRoute } from '../index';
+
+export function getNearestInfo(
+  nearest: LightOnRoute | undefined,
+  recommended: number,
+  nowSec: number,
+) {
+  let nearestInfo = { dist: 0, time: 0 };
+  let nearestStillGreen = false;
+  if (nearest && recommended > 0) {
+    const cycleLen = nearest.cycle.cycle_seconds;
+    const t0 = Date.parse(nearest.cycle.t0_iso) / 1000;
+    const eta = nowSec + nearest.dist_m / ((recommended * 1000) / 3600);
+    const phase = (((eta - t0) % cycleLen) + cycleLen) % cycleLen;
+    const [gs, ge] = getGreenWindow(nearest.cycle, nearest.dirForDriver);
+    nearestStillGreen = phase >= gs + 2 && phase <= ge - 2;
+    let timeToWindow = 0;
+    if (phase < gs) timeToWindow = gs - phase;
+    else if (phase > ge) timeToWindow = cycleLen - phase + gs;
+    nearestInfo = { dist: nearest.dist_m, time: timeToWindow };
+  }
+  return { nearestInfo, nearestStillGreen };
+}


### PR DESCRIPTION
## Summary
- extract computeRecommendation and getNearestInfo into src/navigation
- re-export navigation helpers from index
- cover navigation helpers with focused tests
- document modularization in README

## Testing
- `pre-commit run --files README.md src/index.ts src/__tests__/index.test.ts src/navigation/computeRecommendation.ts src/navigation/computeRecommendation.test.ts src/navigation/getNearestInfo.ts src/navigation/getNearestInfo.test.ts src/navigation/AGENTS.md`
- `npm run lint` *(fails: Unexpected any in src/types/tflite-react-native.d.ts)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aef6cce4c88323b2c2039c7b3acb05