### PR TITLE
feat: notify on signal changes

### DIFF
--- a/__mocks__/expo-notifications.ts
+++ b/__mocks__/expo-notifications.ts
@@ -1,0 +1,4 @@
+export const scheduleNotificationAsync = jest.fn().mockResolvedValue('1');
+export const requestPermissionsAsync = jest
+  .fn()
+  .mockResolvedValue({ status: 'granted' });

--- a/src/interfaces/notifications.ts
+++ b/src/interfaces/notifications.ts
@@ -1,0 +1,10 @@
+export type TrafficSignal = 'red' | 'yellow' | 'green';
+
+export interface SignalEmitter {
+  on(event: 'signal', listener: (signal: TrafficSignal) => void): void;
+}
+
+export interface NotificationsService {
+  subscribeToSignalChanges(emitter: SignalEmitter): void;
+  notifyDriver(signal: TrafficSignal): Promise<void>;
+}

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'events';
+import * as Notifications from 'expo-notifications';
+import { notifyDriver, subscribeToSignalChanges } from '../notifications';
+import type { SignalEmitter } from '../../interfaces/notifications';
+
+jest.mock('expo-notifications');
+
+describe('notifications service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('notifies driver directly', async () => {
+    await notifyDriver('green');
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Signal change',
+        body: 'Signal is now green',
+      },
+      trigger: null,
+    });
+  });
+
+  it('subscribes to signal changes', () => {
+    const emitter = new EventEmitter();
+    subscribeToSignalChanges(emitter as unknown as SignalEmitter);
+    emitter.emit('signal', 'red');
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,27 @@
+import * as Notifications from 'expo-notifications';
+import type {
+  NotificationsService,
+  SignalEmitter,
+  TrafficSignal,
+} from '../interfaces/notifications';
+
+export async function notifyDriver(signal: TrafficSignal): Promise<void> {
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Signal change',
+      body: `Signal is now ${signal}`,
+    },
+    trigger: null,
+  });
+}
+
+export function subscribeToSignalChanges(emitter: SignalEmitter): void {
+  emitter.on('signal', (signal: TrafficSignal) => {
+    void notifyDriver(signal);
+  });
+}
+
+export const notifications: NotificationsService = {
+  subscribeToSignalChanges,
+  notifyDriver,
+};

--- a/src/types/expo-notifications.d.ts
+++ b/src/types/expo-notifications.d.ts
@@ -1,0 +1,14 @@
+declare module 'expo-notifications' {
+  interface NotificationOptions {
+    content: { title: string; body: string };
+    trigger: null | number | Date | Record<string, unknown>;
+  }
+
+  export function scheduleNotificationAsync(
+    options: NotificationOptions,
+  ): Promise<string>;
+
+  export function requestPermissionsAsync(): Promise<{
+    status: 'granted' | 'denied';
+  }>;
+}


### PR DESCRIPTION
## Summary
- add notification interfaces for signal changes
- notify driver via Expo on traffic signal updates
- test signal subscription and notification

## Testing
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68af17432ecc832398b269e185f9ad81