### PR TITLE
refactor: expose navigation helpers via facade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ This repository contains a React Native (Expo) application. New contributors can
 - `assets/` – static images and resources.
 - `App.tsx` – application entry point; renders map, HUD, and menus.
 
+## Newcomer tips
+
+- Start with `README.md` and `CHANGELOG.md` to see recent changes.
+- Navigation helpers live in `src/navigation` and are re-exported from `src/index.ts`.
+- Tests sit next to code; see `src/navigation/__tests__` for examples.
+
 Tests live beside the code they verify, and coverage reports are stored under `coverage/`.
 
 ## Getting started

--- a/App.tsx
+++ b/App.tsx
@@ -26,7 +26,7 @@ import {
   handleClearRoute as clearRoute,
   computeRecommendation,
   LightOnRoute,
-} from './src/navigation';
+} from './src';
 import type { Light, LightCycle } from './src/domain/types';
 
 interface Car {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - Standardized phase color mapping to green for clearer signal status.
 - Reorganized navigation logic under `src/navigation` and scaffolded `src/traffic` and `src/ui` for upcoming features.
 - Modularized navigation helpers for easier testing and reuse.
+- Exposed navigation helpers via `src/index.ts` facade for simpler imports.
 - Handled zero recommended speed to avoid divide-by-zero in nearest info calculation.
 - Tracked traffic light phase durations for analytics.
 - Added offline route caching to reuse the last fetched route when connectivity fails.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  handleStartNavigation,
+  handleClearRoute,
+  initialState,
+  type NavigationState,
+  type LightOnRoute,
+  getNearestInfo,
+  computeRecommendation,
+} from './navigation';

--- a/src/navigation/__tests__/computeRecommendation.test.ts
+++ b/src/navigation/__tests__/computeRecommendation.test.ts
@@ -1,5 +1,5 @@
-import { computeRecommendation } from './computeRecommendation';
-import type { Light, LightCycle } from '../domain/types';
+import { computeRecommendation } from '../computeRecommendation';
+import type { Light, LightCycle } from '../../domain/types';
 
 const light: Light = {
   id: 'l1',

--- a/src/navigation/__tests__/getNearestInfo.test.ts
+++ b/src/navigation/__tests__/getNearestInfo.test.ts
@@ -1,5 +1,5 @@
-import { getNearestInfo } from './getNearestInfo';
-import type { Light, LightCycle } from '../domain/types';
+import { getNearestInfo } from '../getNearestInfo';
+import type { Light, LightCycle } from '../../domain/types';
 
 const light: Light = {
   id: 'l1',

--- a/src/supabase.test.ts
+++ b/src/supabase.test.ts
@@ -20,9 +20,7 @@ describe('fetchLightsAndCycles error handling', () => {
   it('returns error when fetching lights fails', async () => {
     const logger = await import('./services/logger');
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue(undefined);
-    const { supabaseService, supabase } = await import(
-      './services/supabase'
-    );
+    const { supabaseService, supabase } = await import('./services/supabase');
     const { fetchLightsAndCycles } = supabaseService;
     const originalFrom = supabase.from;
 
@@ -45,9 +43,7 @@ describe('fetchLightsAndCycles error handling', () => {
   it('returns error when fetching cycles fails', async () => {
     const logger = await import('./services/logger');
     const logSpy = jest.spyOn(logger, 'log').mockResolvedValue(undefined);
-    const { supabaseService, supabase } = await import(
-      './services/supabase'
-    );
+    const { supabaseService, supabase } = await import('./services/supabase');
     const { fetchLightsAndCycles } = supabaseService;
     const originalFrom = supabase.from;
 

--- a/src/trafficLightDetector.test.ts
+++ b/src/trafficLightDetector.test.ts
@@ -13,11 +13,13 @@ describe('detectTrafficLight', () => {
   });
 
   it('parses model response', async () => {
-    runModelOnImageMock.mockImplementation((opts: any, cb: any) => {
-      cb(null, [
-        { detectedClass: 'green', rect: { x: 1, y: 2, w: 3, h: 4 } },
-      ]);
-    });
+    runModelOnImageMock.mockImplementation(
+      (opts: unknown, cb: (err: Error | null, res?: unknown) => void) => {
+        cb(null, [
+          { detectedClass: 'green', rect: { x: 1, y: 2, w: 3, h: 4 } },
+        ]);
+      },
+    );
     const res = await detectTrafficLight({ base64: 'img' });
     expect(res).toEqual({
       color: 'green',
@@ -26,7 +28,9 @@ describe('detectTrafficLight', () => {
   });
 
   it('returns null on model errors', async () => {
-    runModelOnImageMock.mockImplementation((opts: any, cb: any) => cb(new Error('fail')));
+    runModelOnImageMock.mockImplementation(
+      (opts: unknown, cb: (err: Error | null) => void) => cb(new Error('fail')),
+    );
     await expect(detectTrafficLight({ base64: 'img' })).resolves.toBeNull();
   });
 });

--- a/src/types/tflite-react-native.d.ts
+++ b/src/types/tflite-react-native.d.ts
@@ -1,14 +1,20 @@
 declare module 'tflite-react-native' {
   export default class Tflite {
     loadModel(
-      opts: any,
-      cb: (err: string | null, res?: any) => void,
+      opts: unknown,
+      cb: (err: string | null, res?: unknown) => void,
     ): void;
     runModelOnImage(
-      opts: any,
-      cb: (err: string | null, res?: any) => void,
+      opts: unknown,
+      cb: (err: string | null, res?: unknown) => void,
     ): void;
   }
-  export const runModelOnImageMock: any;
-  export const loadModelMock: any;
+  export const runModelOnImageMock: (
+    opts: unknown,
+    cb: (err: Error | null, res?: unknown) => void,
+  ) => void;
+  export const loadModelMock: (
+    opts: unknown,
+    cb: (err: Error | null, res?: unknown) => void,
+  ) => void;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,6 +1,9 @@
 import i18n from './i18n';
 
-export const validateLight = (name: string, direction: string): string | null => {
+export const validateLight = (
+  name: string,
+  direction: string,
+): string | null => {
   if (!name.trim()) {
     return i18n.t('validation.light.nameRequired');
   }
@@ -30,8 +33,16 @@ export const validateCycle = ({
   pedStart,
   pedEnd,
 }: CycleFields): string | null => {
-  const values = [cycleSeconds, mainStart, mainEnd, secStart, secEnd, pedStart, pedEnd].map(Number);
-  if (values.some(v => Number.isNaN(v))) {
+  const values = [
+    cycleSeconds,
+    mainStart,
+    mainEnd,
+    secStart,
+    secEnd,
+    pedStart,
+    pedEnd,
+  ].map(Number);
+  if (values.some((v) => Number.isNaN(v))) {
     return i18n.t('validation.cycle.numeric');
   }
   if (Number(mainStart) >= Number(mainEnd)) {


### PR DESCRIPTION
## Summary
- add `src/index.ts` barrel re-export for navigation helpers
- move navigation tests into `src/navigation/__tests__`
- document navigation facade and newcomer tips

## Testing
- `npx eslint src/index.ts App.tsx src/navigation/__tests__/computeRecommendation.test.ts src/navigation/__tests__/getNearestInfo.test.ts src/supabase.test.ts src/validation.ts src/trafficLightDetector.test.ts src/types/tflite-react-native.d.ts --format unix`
- `npm test -- src/navigation src/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af95ef0c348323bc43583a4ff3176f