### PR TITLE
feat: notify on phase changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS
 
-This repository contains a React Native (Expo) application. New contributors can start by exploring the folders below to see how the app is assembled.
+This repository contains a React Native (Expo) application for navigating through traffic lights with real-time phase detection.
+New contributors can start by exploring the folders below to see how the app is assembled.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - Converted remaining JavaScript files to TypeScript.
 - Introduced typed interfaces for analytics, network, and Supabase services.
 - Fixed main-direction color mapping and exposed green windows as domain helpers.
-- Added notification service to emit signal change events.
+- Added notification service to emit phase change notifications.
 - Updated cycle seconds translation for clarity.
 
 ## Environment

--- a/src/interfaces/notifications.ts
+++ b/src/interfaces/notifications.ts
@@ -1,10 +1,10 @@
-export type TrafficSignal = 'red' | 'yellow' | 'green';
+export type PhaseColor = 'red' | 'yellow' | 'green';
 
-export interface SignalEmitter {
-  on(event: 'signal', listener: (signal: TrafficSignal) => void): void;
+export interface PhaseEmitter {
+  on(event: 'phase', listener: (phase: PhaseColor) => void): void;
 }
 
 export interface NotificationsService {
-  subscribeToSignalChanges(emitter: SignalEmitter): void;
-  notifyDriver(signal: TrafficSignal): Promise<void>;
+  subscribeToPhaseChanges(emitter: PhaseEmitter): void;
+  notifyDriver(phase: PhaseColor): Promise<void>;
 }

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import * as Notifications from 'expo-notifications';
-import { notifyDriver, subscribeToSignalChanges } from '../notifications';
-import type { SignalEmitter } from '../../interfaces/notifications';
+import { notifyDriver, subscribeToPhaseChanges } from '../notifications';
+import type { PhaseEmitter } from '../../interfaces/notifications';
 
 jest.mock('expo-notifications');
 
@@ -14,17 +14,17 @@ describe('notifications service', () => {
     await notifyDriver('green');
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
       content: {
-        title: 'Signal change',
-        body: 'Signal is now green',
+        title: 'Phase change',
+        body: 'Phase is now green',
       },
       trigger: null,
     });
   });
 
-  it('subscribes to signal changes', () => {
+  it('subscribes to phase changes', () => {
     const emitter = new EventEmitter();
-    subscribeToSignalChanges(emitter as unknown as SignalEmitter);
-    emitter.emit('signal', 'red');
+    subscribeToPhaseChanges(emitter as unknown as PhaseEmitter);
+    emitter.emit('phase', 'red');
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,27 +1,27 @@
 import * as Notifications from 'expo-notifications';
 import type {
   NotificationsService,
-  SignalEmitter,
-  TrafficSignal,
+  PhaseColor,
+  PhaseEmitter,
 } from '../interfaces/notifications';
 
-export async function notifyDriver(signal: TrafficSignal): Promise<void> {
+export async function notifyDriver(phase: PhaseColor): Promise<void> {
   await Notifications.scheduleNotificationAsync({
     content: {
-      title: 'Signal change',
-      body: `Signal is now ${signal}`,
+      title: 'Phase change',
+      body: `Phase is now ${phase}`,
     },
     trigger: null,
   });
 }
 
-export function subscribeToSignalChanges(emitter: SignalEmitter): void {
-  emitter.on('signal', (signal: TrafficSignal) => {
-    void notifyDriver(signal);
+export function subscribeToPhaseChanges(emitter: PhaseEmitter): void {
+  emitter.on('phase', (phase: PhaseColor) => {
+    void notifyDriver(phase);
   });
 }
 
 export const notifications: NotificationsService = {
-  subscribeToSignalChanges,
+  subscribeToPhaseChanges,
   notifyDriver,
 };


### PR DESCRIPTION
## Summary
- notify drivers when traffic light phases change using Expo Notifications
- document phase notifications and expand contributor guide

## Testing
- `npm test -- src/services/notifications.ts` *(fails: No tests found)*
- `npm test -- src/services/__tests__/notifications.test.ts`
- `npm test -- --coverage src/services/__tests__/notifications.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af9b3383208323971a4b3c6f03d0b2