### PR TITLE
chore: add navigation factory and lint fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,13 @@ New contributors can start by exploring the folders below to see how the app is 
 - `src/domain/` – shared domain types and matching utilities.
 - `assets/` – static images and resources.
 - `App.tsx` – application entry point; renders map, HUD, and menus.
+- `data/app.log` – file logger output written via `src/services/logger.ts`.
 
 ## Newcomer tips
 
 - Start with `README.md` and `CHANGELOG.md` to see recent changes.
 - Navigation helpers live in `src/navigation` and are re-exported from `src/index.ts`.
+- Use `createNavigation()` from `src/index.ts` to obtain test-friendly navigation helpers.
 - Tests sit next to code; see `src/navigation/__tests__` for examples.
 
 Tests live beside the code they verify, and coverage reports are stored under `coverage/`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - Fixed main-direction color mapping and exposed green windows as domain helpers.
 - Added notification service to emit phase change notifications.
 - Updated cycle seconds translation for clarity.
+- Introduced a navigation factory for easier testing of navigation helpers.
 
 ## Environment
 

--- a/src/domain/matching.ts
+++ b/src/domain/matching.ts
@@ -10,7 +10,7 @@ function toXY([lat, lon]: [number, number]) {
 function projectPointToSegment(
   p: [number, number],
   a: [number, number],
-  b: [number, number]
+  b: [number, number],
 ) {
   const P = toXY(p);
   const A = toXY(a);
@@ -33,7 +33,7 @@ function projectPointToSegment(
 
 export function projectLightsToRoute(
   lights: Light[],
-  route: RouteLeg[]
+  route: RouteLeg[],
 ): { light: Light; dist_m: number; order_m: number }[] {
   const coords: [number, number][] = [];
   for (const leg of route) coords.push(...leg.coords);
@@ -60,7 +60,7 @@ export function projectLightsToRoute(
       const { dist, t } = projectPointToSegment(
         [light.lat, light.lon],
         seg.a,
-        seg.b
+        seg.b,
       );
       if (dist < bestDist) {
         bestDist = dist;

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,7 +1,7 @@
 jest.mock(
   'expo-localization',
   () => ({ getLocales: () => [{ languageTag: 'en-US' }] }),
-  { virtual: true }
+  { virtual: true },
 );
 
 import i18n from './i18n';
@@ -15,7 +15,7 @@ describe('i18n translations', () => {
       time: 20,
     });
     expect(res).toBe(
-      'Рекомендуем 40 км/ч • ближайший светофор через 100 м • окно через 20 с'
+      'Рекомендуем 40 км/ч • ближайший светофор через 100 м • окно через 20 с',
     );
   });
 
@@ -27,7 +27,7 @@ describe('i18n translations', () => {
       time: 20,
     });
     expect(res).toBe(
-      'Recommended 40 km/h • next light in 100 m • window in 20 s'
+      'Recommended 40 km/h • next light in 100 m • window in 20 s',
     );
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,16 @@
+import { createNavigation, initialState } from './index';
+
+describe('index facade', () => {
+  it('creates navigation helpers', () => {
+    const nav = createNavigation();
+    const track = jest.fn();
+    nav.handleStartNavigation(track);
+    expect(track).toHaveBeenCalledWith('navigation_start');
+  });
+
+  it('returns a copy of initial state', () => {
+    const nav = createNavigation();
+    expect(nav.initialState).toEqual(initialState);
+    expect(nav.initialState).not.toBe(initialState);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,28 @@
+import {
+  handleStartNavigation,
+  handleClearRoute,
+  initialState,
+  getNearestInfo,
+  computeRecommendation,
+} from './navigation';
+import type { NavigationState, LightOnRoute } from './navigation';
+
 export {
   handleStartNavigation,
   handleClearRoute,
   initialState,
-  type NavigationState,
-  type LightOnRoute,
   getNearestInfo,
   computeRecommendation,
-} from './navigation';
+  type NavigationState,
+  type LightOnRoute,
+};
+
+export function createNavigation() {
+  return {
+    handleStartNavigation,
+    handleClearRoute,
+    initialState: { ...initialState },
+    getNearestInfo,
+    computeRecommendation,
+  };
+}

--- a/src/navigation/advisor.test.ts
+++ b/src/navigation/advisor.test.ts
@@ -20,14 +20,22 @@ describe('advisor pickSpeed', () => {
   };
 
   it('recommends speed hitting green window', () => {
-    const res = pickSpeed(0, [{ light, cycle: baseCycle, dist_m: 500, dirForDriver: 'MAIN' }], 50);
+    const res = pickSpeed(
+      0,
+      [{ light, cycle: baseCycle, dist_m: 500, dirForDriver: 'MAIN' }],
+      50,
+    );
     expect(res.reason).toBe('nearest-green');
     expect(res.recommended).toBeGreaterThanOrEqual(47); // within window
     expect(res.recommended).toBeLessThanOrEqual(56);
   });
 
   it('respects delta buffer at window edges', () => {
-    const res = pickSpeed(0, [{ light, cycle: baseCycle, dist_m: 500, dirForDriver: 'MAIN' }], 60);
+    const res = pickSpeed(
+      0,
+      [{ light, cycle: baseCycle, dist_m: 500, dirForDriver: 'MAIN' }],
+      60,
+    );
     // 60 km/h would arrive exactly at 30s, outside due to delta
     expect(res.recommended).not.toBe(60);
   });

--- a/src/navigation/advisor.ts
+++ b/src/navigation/advisor.ts
@@ -9,19 +9,26 @@ export function pickSpeed(
     dist_m: number;
     dirForDriver: Direction;
   }[],
-  vRealKmh: number
-): { recommended: number; reason: 'nearest-green' | 'global-score' | 'no-data' } {
+  vRealKmh: number,
+): {
+  recommended: number;
+  reason: 'nearest-green' | 'global-score' | 'no-data';
+} {
   const candidates = Array.from({ length: 61 }, (_, i) => 20 + i);
   if (!lightsOnRoute.length)
     return {
       recommended: Math.max(20, Math.min(80, Math.round(vRealKmh || 50))),
-      reason: 'no-data'
+      reason: 'no-data',
     };
 
-  let best: { v: number; score: number; reason: 'nearest-green' | 'global-score' } = {
+  let best: {
+    v: number;
+    score: number;
+    reason: 'nearest-green' | 'global-score';
+  } = {
     v: 50,
     score: -1,
-    reason: 'global-score'
+    reason: 'global-score',
   };
   for (const v of candidates) {
     let score = 0,
@@ -31,8 +38,8 @@ export function pickSpeed(
       if (!L.cycle) continue;
       const cycle = L.cycle.cycle_seconds;
       const t0 = Date.parse(L.cycle.t0_iso) / 1000;
-      const eta = nowSec + L.dist_m / (v * 1000 / 3600);
-      const phase = ((eta - t0) % cycle + cycle) % cycle;
+      const eta = nowSec + L.dist_m / ((v * 1000) / 3600);
+      const phase = (((eta - t0) % cycle) + cycle) % cycle;
       const [gs, ge] = getGreenWindow(L.cycle, L.dirForDriver);
       const inWin = phase >= gs + 2 && phase <= ge - 2;
       if (inWin) score += ge - gs;
@@ -44,7 +51,7 @@ export function pickSpeed(
       best = {
         v,
         score: finalScore,
-        reason: okNearest ? 'nearest-green' : 'global-score'
+        reason: okNearest ? 'nearest-green' : 'global-score',
       };
   }
   return { recommended: best.v, reason: best.reason };
@@ -53,7 +60,7 @@ export function pickSpeed(
 export function applyHysteresis(
   previous: number,
   next: number,
-  nearestStillGreen: boolean
+  nearestStillGreen: boolean,
 ) {
   if (!nearestStillGreen) return next;
   if (Math.abs(previous - next) < 3) return previous;

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -56,7 +56,9 @@ async function fetchLightsAndCycles(): Promise<{
   };
 }
 
-function subscribeLightCycles(cb: (cycle: LightCycle) => void): RealtimeChannel {
+function subscribeLightCycles(
+  cb: (cycle: LightCycle) => void,
+): RealtimeChannel {
   return supabase
     .channel('public:light_cycles')
     .on(


### PR DESCRIPTION
## Summary
- add testable `createNavigation` factory and unit tests
- document logger output and navigation factory in AGENTS
- fix formatting warnings across navigation, domain, i18n, and supabase

## Testing
- `npm test -- --coverage`
- `npm start` *(fails: Cannot find module 'metro/src/ModuleGraph/worker/importLocationsPlugin')*


------
https://chatgpt.com/codex/tasks/task_e_68afc17005088323946e43ee8a2a94d3