### PR TITLE
feat: add theme state and settings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { Alert, StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import Settings from './src/ui/Settings';
+import { color as themeColorValue, loadFromStorage } from './src/state/theme';
 import MapView, {
   Marker,
   Polyline,
@@ -16,7 +18,10 @@ import SpeedBanner from './src/features/navigation/ui/SpeedBanner';
 import MainMenu from './src/ui/MainMenu';
 import { supabaseService, supabase } from './src/services/supabase';
 import { getRoute, RouteStep } from './src/features/navigation/services/ors';
-import { saveRoute, loadRoute } from './src/features/navigation/services/routeCache';
+import {
+  saveRoute,
+  loadRoute,
+} from './src/features/navigation/services/routeCache';
 import i18n from './src/i18n';
 import { mapColorForRuntime } from './src/features/navigation/phases';
 import { projectLightsToRoute } from './src/domain/matching';
@@ -63,6 +68,8 @@ export default function App(): JSX.Element {
   });
   const [, setSteps] = useState<RouteStep[]>([]);
   const [menuVisible, setMenuVisible] = useState<boolean>(false);
+  const [themeColor, setThemeColor] = useState(themeColorValue);
+  const [settingsVisible, setSettingsVisible] = useState(false);
 
   const onStartNavigation = () => {
     startNavigation(analytics.trackEvent);
@@ -89,6 +96,7 @@ export default function App(): JSX.Element {
   const handleSettings = () => {
     analytics.trackEvent('settings_change');
     setMenuVisible(false);
+    setSettingsVisible(true);
   };
 
   useEffect(() => {
@@ -125,6 +133,10 @@ export default function App(): JSX.Element {
     return () => {
       supabase.removeChannel(sub);
     };
+  }, []);
+
+  useEffect(() => {
+    loadFromStorage().then(() => setThemeColor(themeColorValue));
   }, []);
 
   useEffect(() => {
@@ -221,7 +233,7 @@ export default function App(): JSX.Element {
   }, [lightsOnRoute, car, nowSec, recommended]);
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: themeColor }]}>
       {loadError && <Text testID="load-error">{loadError}</Text>}
       <MapView
         ref={mapRef}
@@ -292,6 +304,11 @@ export default function App(): JSX.Element {
           onCancel={() => setCycleModal(null)}
         />
       )}
+      <Settings
+        visible={settingsVisible}
+        onClose={() => setSettingsVisible(false)}
+        onColor={(c) => setThemeColor(c)}
+      />
     </View>
   );
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - Handled zero recommended speed to avoid divide-by-zero in nearest info calculation.
 - Tracked traffic light phase durations for analytics.
 - Added offline route caching to reuse the last fetched route when connectivity fails.
+- Introduced persistent theme color with settings screen.
 - Consolidated project structure by moving `components/` and `services/` into `src/`.
 - Fixed HUD maneuver spacing.
 - Updated localization string spacing.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,4 +20,11 @@ describe('index facade', () => {
     expect(nav.initialState).toEqual(custom);
     expect(nav.initialState).not.toBe(custom);
   });
+
+  it('allows injecting handlers', () => {
+    const custom = jest.fn();
+    const nav = createNavigation(undefined, { handleStartNavigation: custom });
+    nav.handleStartNavigation(jest.fn());
+    expect(custom).toHaveBeenCalled();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,32 @@ import {
 } from './features/navigation';
 import type { NavigationState, LightOnRoute } from './features/navigation';
 
+export interface NavigationDeps {
+  handleStartNavigation: typeof handleStartNavigation;
+  handleClearRoute: typeof handleClearRoute;
+  getNearestInfo: typeof getNearestInfo;
+  computeRecommendation: typeof computeRecommendation;
+}
+
+export function createNavigation(
+  state: NavigationState = initialState,
+  deps: Partial<NavigationDeps> = {},
+) {
+  const {
+    handleStartNavigation: start = handleStartNavigation,
+    handleClearRoute: clear = handleClearRoute,
+    getNearestInfo: nearest = getNearestInfo,
+    computeRecommendation: compute = computeRecommendation,
+  } = deps;
+  return {
+    handleStartNavigation: start,
+    handleClearRoute: clear,
+    initialState: { ...state },
+    getNearestInfo: nearest,
+    computeRecommendation: compute,
+  };
+}
+
 export {
   handleStartNavigation,
   handleClearRoute,
@@ -16,15 +42,3 @@ export {
   type NavigationState,
   type LightOnRoute,
 };
-
-export function createNavigation(
-  state: NavigationState = initialState,
-) {
-  return {
-    handleStartNavigation,
-    handleClearRoute,
-    initialState: { ...state },
-    getNearestInfo,
-    computeRecommendation,
-  };
-}

--- a/src/services/network.ts
+++ b/src/services/network.ts
@@ -1,4 +1,4 @@
-import type { Network, FetchOptions } from '../interfaces/network';
+import type { Network } from '../interfaces/network';
 
 export const network: Network = {
   async fetchWithTimeout(input, options = {}) {
@@ -23,11 +23,14 @@ export const network: Network = {
         throw new Error(`Request failed with status ${res.status}: ${message}`);
       }
       return res;
-    } catch (err: any) {
-      if (err.name === 'AbortError') {
-        throw new Error('Request timed out. Please try again.');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        if (err.name === 'AbortError') {
+          throw new Error('Request timed out. Please try again.');
+        }
+        throw new Error(err.message || 'Network request failed.');
       }
-      throw new Error(err.message || 'Network request failed.');
+      throw new Error('Network request failed.');
     } finally {
       clearTimeout(id);
     }

--- a/src/services/tests/logger.test.ts
+++ b/src/services/tests/logger.test.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 describe('log', () => {
   const fixed = new Date(Date.UTC(2023, 0, 2, 3, 4, 5));
 
@@ -12,23 +14,17 @@ describe('log', () => {
   });
 
   it('appends formatted line with fs', async () => {
-    jest.doMock('fs', () => ({
+    jest.mock('fs', () => ({
       appendFileSync: jest.fn(),
       existsSync: jest.fn().mockReturnValue(true),
       mkdirSync: jest.fn(),
     }));
-
-    let log: any;
-    let fs: any;
-    jest.isolateModules(() => {
-      log = require('../logger').log;
-      fs = require('fs');
-    });
+    const { log } = await import('../logger');
+    const fs = await import('fs');
     await log('INFO', 'hello');
     expect(fs.appendFileSync).toHaveBeenCalledWith(
-      require('path').join('data', 'app.log'),
+      path.join('data', 'app.log'),
       '2023-01-02 03:04:05 [INFO] hello\n',
     );
   });
-
 });

--- a/src/state/theme.test.ts
+++ b/src/state/theme.test.ts
@@ -1,0 +1,24 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { color, setColor, loadFromStorage } from './theme';
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('@react-native-async-storage/async-storage/jest/async-storage-mock');
+});
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('theme state', () => {
+  it('loads color from storage', async () => {
+    await AsyncStorage.setItem('theme_color', 'red');
+    await loadFromStorage();
+    expect(color).toBe('red');
+  });
+
+  it('saves color to storage', async () => {
+    await setColor('blue');
+    expect(await AsyncStorage.getItem('theme_color')).toBe('blue');
+  });
+});

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = 'theme_color';
+
+export let color = 'light';
+
+export async function setColor(value: string): Promise<void> {
+  color = value;
+  await AsyncStorage.setItem(KEY, value);
+}
+
+export async function loadFromStorage(): Promise<void> {
+  const stored = await AsyncStorage.getItem(KEY);
+  if (stored) color = stored;
+}

--- a/src/ui/MainMenu.tsx
+++ b/src/ui/MainMenu.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import i18n from '../i18n';
 import { usePremium } from '../premium/subscription';
-import {
-  PremiumFeature,
-  requiresPremium,
-} from '../premium/features';
+import { PremiumFeature, requiresPremium } from '../premium/features';
+
+const MENU_BG = 'rgba(0,0,0,0.8)';
+const TEXT_COLOR = '#fff';
 
 export interface MainMenuProps {
   visible: boolean;
@@ -46,19 +46,18 @@ export default function MainMenu({
 
 const styles = StyleSheet.create({
   container: {
-    position: 'absolute',
-    bottom: 80,
-    right: 20,
-    backgroundColor: 'rgba(0,0,0,0.8)',
-    padding: 8,
+    backgroundColor: MENU_BG,
     borderRadius: 6,
+    bottom: 80,
+    padding: 8,
+    position: 'absolute',
+    right: 20,
   },
   item: {
     paddingVertical: 4,
   },
   text: {
-    color: '#fff',
+    color: TEXT_COLOR,
     fontSize: 16,
   },
 });
-

--- a/src/ui/Settings.tsx
+++ b/src/ui/Settings.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Modal, View, Button, StyleSheet } from 'react-native';
+import { setColor } from '../state/theme';
+
+export interface SettingsProps {
+  visible: boolean;
+  onClose: () => void;
+  onColor: (c: string) => void;
+}
+
+export default function Settings({
+  visible,
+  onClose,
+  onColor,
+}: SettingsProps): JSX.Element {
+  const choose = async (c: string) => {
+    await setColor(c);
+    onColor(c);
+  };
+
+  return (
+    <Modal transparent visible={visible} animationType="slide">
+      <View style={styles.container}>
+        <Button title="Red" onPress={() => choose('red')} />
+        <Button title="Blue" onPress={() => choose('blue')} />
+        <Button title="Close" onPress={onClose} />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    backgroundColor: BG_COLOR,
+    flex: 1,
+    justifyContent: 'center',
+  },
+});
+
+const BG_COLOR = 'white';

--- a/src/ui/__tests__/MainMenu.test.tsx
+++ b/src/ui/__tests__/MainMenu.test.tsx
@@ -22,7 +22,7 @@ describe('MainMenu', () => {
         onClearRoute={noop}
         onAddLight={noop}
         onSettings={noop}
-      />
+      />,
     );
     expect(getByTestId('main-menu')).toBeTruthy();
     expect(getByText('Start Navigation')).toBeTruthy();
@@ -36,7 +36,7 @@ describe('MainMenu', () => {
         onClearRoute={noop}
         onAddLight={noop}
         onSettings={noop}
-      />
+      />,
     );
     expect(queryByTestId('main-menu')).toBeNull();
   });


### PR DESCRIPTION
## Summary
- add persistent theme state with storage helpers
- expose Settings modal to change theme color
- inject navigation dependencies for easier testing

## Testing
- `npx eslint App.tsx src/state/theme.ts src/state/theme.test.ts src/ui/Settings.tsx src/ui/MainMenu.tsx src/ui/__tests__/MainMenu.test.tsx src/services/tests/logger.test.ts src/index.ts src/index.test.ts src/services/network.ts`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68afe3ee1d808323b52afee258a8649f