### PR TITLE
feat: add speech guidance for maneuvers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import { Alert, StyleSheet, View, Text, TouchableOpacity } from 'react-native';
 import Settings from './src/ui/Settings';
 import { color as themeColorValue, loadFromStorage } from './src/state/theme';
+import { loadSpeechEnabled } from './src/state/speech';
 import MapView, {
   Marker,
   Polyline,
@@ -137,6 +138,7 @@ export default function App(): JSX.Element {
 
   useEffect(() => {
     loadFromStorage().then(() => setThemeColor(themeColorValue));
+    loadSpeechEnabled();
   }, []);
 
   useEffect(() => {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - Tracked traffic light phase durations for analytics.
 - Added offline route caching to reuse the last fetched route when connectivity fails.
 - Introduced persistent theme color with settings screen.
+- Added voice guidance for maneuvers with Expo Speech and a settings toggle.
 - Consolidated project structure by moving `components/` and `services/` into `src/`.
 - Fixed HUD maneuver spacing.
 - Updated localization string spacing.

--- a/__mocks__/expo-speech.ts
+++ b/__mocks__/expo-speech.ts
@@ -1,0 +1,1 @@
+export const speak = jest.fn();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "expo-in-app-purchases": "^14.5.0",
         "expo-localization": "^16.1.6",
         "expo-location": "^18.0.0",
+        "expo-speech": "^13.1.7",
         "i18n-js": "^4.5.1",
         "metro": "0.81.1",
         "react": "18.2.0",
@@ -563,7 +564,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
       "integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -580,7 +580,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
       "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -596,7 +595,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
       "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -612,7 +610,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
       "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -630,7 +627,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
       "integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -821,7 +817,6 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -945,7 +940,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
       "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -961,7 +955,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
       "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1137,7 +1130,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
@@ -1203,7 +1195,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
       "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1250,7 +1241,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
       "integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.28.3",
@@ -1319,7 +1309,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
       "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1336,7 +1325,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
       "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1352,7 +1340,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
       "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1369,7 +1356,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
       "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1385,7 +1371,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
       "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1402,7 +1387,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
       "integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1482,7 +1466,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
       "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1528,7 +1511,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
       "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1544,7 +1526,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
       "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1577,7 +1558,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
       "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1596,7 +1576,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
       "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1629,7 +1608,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
       "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1694,7 +1672,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
       "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1790,7 +1767,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
       "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1916,7 +1892,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
       "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1933,7 +1908,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
       "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2024,7 +1998,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2040,7 +2013,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
       "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2075,7 +2047,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
       "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -2091,7 +2062,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
       "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -2124,7 +2094,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
       "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -2141,7 +2110,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.3.tgz",
       "integrity": "sha512-ROiDcM+GbYVPYBOeCR6uBXKkQpBExLl8k9HO1ygXEyds39j+vCCsjmj7S8GOniZQlEs81QlkdJZe76IpLSiqpg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.0",
@@ -2226,7 +2194,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2253,7 +2220,6 @@
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -6156,14 +6122,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -7996,7 +7962,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -9049,7 +9015,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9312,6 +9277,15 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-speech": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-13.1.7.tgz",
+      "integrity": "sha512-RMMgK6IIPQD9uLhmY2Q9v+2j3wmTGqB/qZ7sdy5//5TLCzFwAq1vlpy5A2psVsctoWVxUO4EmlaNai0ahQmKRg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-in-app-purchases": "^14.5.0",
     "expo-localization": "^16.1.6",
     "expo-location": "^18.0.0",
+    "expo-speech": "^13.1.7",
     "i18n-js": "^4.5.1",
     "metro": "0.81.1",
     "react": "18.2.0",

--- a/src/features/navigation/ui/DrivingHUD.tsx
+++ b/src/features/navigation/ui/DrivingHUD.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
+import * as Speech from 'expo-speech';
 import i18n from '../../../i18n';
 import { usePremium } from '../../../premium/subscription';
 import {
   PremiumFeature,
   requiresPremium,
 } from '../../../premium/features';
+import { speechEnabled } from '../../../state/speech';
 
 export interface DrivingHUDProps {
   maneuver?: string;
@@ -27,6 +29,19 @@ export default function DrivingHUD({
   const { isPremium } = usePremium();
   const speedKmh = Math.round(speed || 0);
   const limit = speedLimit ? Math.round(speedLimit) : '--';
+  const spoken = useRef<string | undefined>();
+
+  useEffect(() => {
+    if (speechEnabled && maneuver && spoken.current !== maneuver) {
+      Speech.speak(
+        i18n.t('hud.maneuver', {
+          maneuver,
+          distance: Math.round(distance ?? 0),
+        }),
+      );
+      spoken.current = maneuver;
+    }
+  }, [maneuver, distance]);
   return (
     <SafeAreaView style={styles.container} pointerEvents="none">
       <View style={styles.maneuvers}>
@@ -61,41 +76,49 @@ export default function DrivingHUD({
   );
 }
 
+const PANEL_BG = 'rgba(0,0,0,0.6)';
+const TEXT_COLOR = '#fff';
+
 const styles = StyleSheet.create({
   container: {
     ...StyleSheet.absoluteFillObject,
     justifyContent: 'space-between',
   },
-  maneuvers: {
-    alignSelf: 'center',
-    marginTop: 10,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    padding: 8,
-    borderRadius: 6,
-  },
-  speedPanel: {
-    position: 'absolute',
-    left: 10,
-    bottom: 60,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    padding: 8,
-    borderRadius: 6,
-  },
-  streetPanel: {
-    position: 'absolute',
-    alignSelf: 'center',
-    bottom: 60,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    padding: 8,
-    borderRadius: 6,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    width: 200,
-  },
   etaPanel: {
     alignSelf: 'stretch',
-    backgroundColor: 'rgba(0,0,0,0.6)',
+    backgroundColor: PANEL_BG,
     padding: 8,
   },
-  text: { color: '#fff', textAlign: 'center', fontSize: 16, fontWeight: '600' }
+  maneuvers: {
+    alignSelf: 'center',
+    backgroundColor: PANEL_BG,
+    borderRadius: 6,
+    marginTop: 10,
+    padding: 8,
+  },
+  speedPanel: {
+    backgroundColor: PANEL_BG,
+    borderRadius: 6,
+    bottom: 60,
+    left: 10,
+    padding: 8,
+    position: 'absolute',
+  },
+  streetPanel: {
+    alignSelf: 'center',
+    backgroundColor: PANEL_BG,
+    borderRadius: 6,
+    bottom: 60,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    padding: 8,
+    position: 'absolute',
+    width: 200,
+  },
+  text: {
+    color: TEXT_COLOR,
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
 });

--- a/src/features/navigation/ui/__tests__/DrivingHUD.test.tsx
+++ b/src/features/navigation/ui/__tests__/DrivingHUD.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 
 jest.mock('expo-localization');
 jest.mock('react-native', () => ({
@@ -11,6 +11,9 @@ jest.mock('react-native', () => ({
 jest.mock('../../../../premium/subscription', () => ({
   usePremium: () => ({ isPremium: true }),
 }));
+jest.mock('expo-speech');
+jest.mock('../../../../state/speech', () => ({ speechEnabled: true }));
+import * as Speech from 'expo-speech';
 
 import DrivingHUD from '../DrivingHUD';
 
@@ -30,5 +33,14 @@ describe('DrivingHUD', () => {
     expect(getByTestId('hud-street').props.children).toBe('Main St');
     expect(getByTestId('hud-eta').props.children).toBe('ETA: 60s');
     expect(getByTestId('hud-speed-limit').props.children).toBe('Limit: 50');
+  });
+
+  it('speaks maneuver when enabled', async () => {
+    render(
+      <DrivingHUD maneuver="Turn left" distance={100} street="" eta={0} speed={0} />,
+    );
+    await waitFor(() =>
+      expect(Speech.speak).toHaveBeenCalledWith('Turn left in 100 m'),
+    );
   });
 });

--- a/src/state/speech.test.ts
+++ b/src/state/speech.test.ts
@@ -1,0 +1,24 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { speechEnabled, setSpeechEnabled, loadSpeechEnabled } from './speech';
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('@react-native-async-storage/async-storage/jest/async-storage-mock');
+});
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('speech state', () => {
+  it('loads flag from storage', async () => {
+    await AsyncStorage.setItem('speech_enabled', '0');
+    await loadSpeechEnabled();
+    expect(speechEnabled).toBe(false);
+  });
+
+  it('saves flag to storage', async () => {
+    await setSpeechEnabled(false);
+    expect(await AsyncStorage.getItem('speech_enabled')).toBe('0');
+  });
+});

--- a/src/state/speech.ts
+++ b/src/state/speech.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = 'speech_enabled';
+
+export let speechEnabled = true;
+
+export async function setSpeechEnabled(value: boolean): Promise<void> {
+  speechEnabled = value;
+  await AsyncStorage.setItem(KEY, value ? '1' : '0');
+}
+
+export async function loadSpeechEnabled(): Promise<void> {
+  const stored = await AsyncStorage.getItem(KEY);
+  if (stored !== null) speechEnabled = stored === '1';
+}

--- a/src/ui/Settings.tsx
+++ b/src/ui/Settings.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Modal, View, Button, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { Modal, View, Button, StyleSheet, Switch, Text } from 'react-native';
 import { setColor } from '../state/theme';
+import { speechEnabled, setSpeechEnabled } from '../state/speech';
 
 export interface SettingsProps {
   visible: boolean;
@@ -17,10 +18,24 @@ export default function Settings({
     await setColor(c);
     onColor(c);
   };
+  const [voice, setVoice] = useState(speechEnabled);
+
+  const toggleSpeech = async (v: boolean) => {
+    setVoice(v);
+    await setSpeechEnabled(v);
+  };
 
   return (
     <Modal transparent visible={visible} animationType="slide">
       <View style={styles.container}>
+        <View style={styles.row}>
+          <Text style={styles.label}>Voice</Text>
+          <Switch
+            testID="speech-toggle"
+            value={voice}
+            onValueChange={toggleSpeech}
+          />
+        </View>
         <Button title="Red" onPress={() => choose('red')} />
         <Button title="Blue" onPress={() => choose('blue')} />
         <Button title="Close" onPress={onClose} />
@@ -28,6 +43,7 @@ export default function Settings({
     </Modal>
   );
 }
+const BG_COLOR = 'white';
 
 const styles = StyleSheet.create({
   container: {
@@ -36,6 +52,12 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
   },
+  label: {
+    marginRight: 8,
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: 8,
+  },
 });
-
-const BG_COLOR = 'white';

--- a/src/ui/__tests__/Settings.test.tsx
+++ b/src/ui/__tests__/Settings.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+jest.mock('react-native', () => ({
+  Modal: 'Modal',
+  View: 'View',
+  Button: 'Button',
+  StyleSheet: { create: () => ({}), flatten: () => ({}) },
+  Switch: 'Switch',
+  Text: 'Text',
+}));
+
+jest.mock('../../state/theme', () => ({ setColor: jest.fn() }));
+const setSpeechEnabled = jest.fn();
+jest.mock('../../state/speech', () => ({
+  speechEnabled: true,
+  setSpeechEnabled: (v: boolean) => setSpeechEnabled(v),
+}));
+
+import Settings from '../Settings';
+
+describe('Settings', () => {
+  it('toggles speech', () => {
+    const { getByTestId } = render(
+      <Settings visible onClose={() => {}} onColor={() => {}} />,
+    );
+    fireEvent(getByTestId('speech-toggle'), 'valueChange', false);
+    expect(setSpeechEnabled).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary
- install expo-speech and persist speech setting
- speak upcoming maneuvers in DrivingHUD when enabled
- add settings toggle and tests with speech mocked

## Testing
- `pre-commit run --files App.tsx README.md package-lock.json package.json src/features/navigation/ui/DrivingHUD.tsx src/features/navigation/ui/__tests__/DrivingHUD.test.tsx src/ui/Settings.tsx __mocks__/expo-speech.ts src/state/speech.test.ts src/state/speech.ts src/ui/__tests__/Settings.test.tsx`
- `npx eslint App.tsx src/features/navigation/ui/DrivingHUD.tsx src/features/navigation/ui/__tests__/DrivingHUD.test.tsx src/state/speech.ts src/state/speech.test.ts src/ui/__tests__/Settings.test.tsx`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68afe91b9be08323be969a76bf8b605d