### PR TITLE
docs: hyphenate traffic-light

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - Modularized navigation helpers for easier testing and reuse.
 - Exposed navigation helpers via `src/index.ts` facade for simpler imports.
 - Handled zero recommended speed to avoid divide-by-zero in nearest info calculation.
-- Tracked traffic light phase durations for analytics.
+- Tracked traffic-light phase durations for analytics.
 - Added offline route caching to reuse the last fetched route when connectivity fails.
 - Introduced persistent theme color with settings screen.
 - Added voice guidance for maneuvers with Expo Speech and a settings toggle.


### PR DESCRIPTION
## Summary
- use hyphenated form "traffic-light" in README

## Testing
- `pre-commit run --files README.md`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test -- --coverage` *(fails: jest not found; npm install conflicted dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68afeed69b20832384b78028cc4b3e8d