### PR TITLE
Handle empty lights array in computeRecommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Retain previous recommendation when no traffic lights are on the route.
 - Introduced navigation factory helpers for modular routing and easier tests.
 - Added phase-change notifications to alert on traffic light transitions.
 - Switched analytics tracking to `@react-native-firebase/analytics` with a typed service wrapper.

--- a/src/features/navigation/__tests__/computeRecommendation.test.ts
+++ b/src/features/navigation/__tests__/computeRecommendation.test.ts
@@ -40,4 +40,15 @@ describe('computeRecommendation', () => {
     );
     expect(recommended).toBe(52);
   });
+
+  it('returns previous recommendation when no lights on route', () => {
+    const { recommended, nearestInfo } = computeRecommendation(
+      [],
+      { speed: 50 / 3.6 },
+      0,
+      42,
+    );
+    expect(recommended).toBe(42);
+    expect(nearestInfo).toEqual({ dist: 0, time: 0 });
+  });
 });

--- a/src/features/navigation/computeRecommendation.ts
+++ b/src/features/navigation/computeRecommendation.ts
@@ -8,6 +8,9 @@ export function computeRecommendation(
   nowSec: number,
   prevRecommended: number,
 ) {
+  if (lightsOnRoute.length === 0) {
+    return { recommended: prevRecommended, nearestInfo: { dist: 0, time: 0 } };
+  }
   const res = pickSpeed(nowSec, lightsOnRoute, car.speed * 3.6);
   const { nearestInfo, nearestStillGreen } = getNearestInfo(
     lightsOnRoute[0],


### PR DESCRIPTION
## Summary
- return previous recommendation when no traffic lights are on route
- test no-lights case for computeRecommendation
- document behaviour in README

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aff0050e448323b6ca1fb9dbf49dee