### PR TITLE
docs: add changelog and tidy lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ New contributors can start by exploring the folders below to see how the app is 
 
 ## Newcomer tips
 
-- Start with `README.md` and `CHANGELOG.md` to see recent changes.
+- Start with [`README.md`](README.md) and [`CHANGELOG.md`](CHANGELOG.md) to see recent changes.
 - Navigation helpers live in `src/features/navigation` and are re-exported from `src/index.ts`.
 - Use `createNavigation()` from `src/index.ts` to obtain test-friendly navigation helpers.
 - Tests sit next to code; see `src/features/navigation/__tests__` for examples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2025-08
+
+- fix: handle empty lights array to preserve recommendations when no lights are present
+- docs: hyphenate the term traffic-light for consistency
+- feat: add speech guidance for maneuvers
+- feat: add theme state with settings screen
+- refactor: group navigation and traffic modules under `src/features`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - Fixed main-direction color mapping and exposed green windows as domain helpers.
 - Updated cycle seconds translation for clarity.
 
+See [CHANGELOG.md](CHANGELOG.md) for a full history.
+
 ## Environment
 
 Set the following environment variables for API access:

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -26,27 +26,27 @@ describe('validateCycle', () => {
   };
 
   test('numbers required', () => {
-    expect(
-      validateCycle({ ...base, cycleSeconds: 'abc' })
-    ).toBe('All numeric fields must be valid numbers');
+    expect(validateCycle({ ...base, cycleSeconds: 'abc' })).toBe(
+      'All numeric fields must be valid numbers',
+    );
   });
 
   test('main start must be less than end', () => {
-    expect(
-      validateCycle({ ...base, mainStart: '5', mainEnd: '5' })
-    ).toBe('Main start must be less than end');
+    expect(validateCycle({ ...base, mainStart: '5', mainEnd: '5' })).toBe(
+      'Main start must be less than end',
+    );
   });
 
   test('secondary start must be less than end', () => {
-    expect(
-      validateCycle({ ...base, secStart: '15', secEnd: '15' })
-    ).toBe('Secondary start must be less than end');
+    expect(validateCycle({ ...base, secStart: '15', secEnd: '15' })).toBe(
+      'Secondary start must be less than end',
+    );
   });
 
   test('pedestrian start must be less than end', () => {
-    expect(
-      validateCycle({ ...base, pedStart: '25', pedEnd: '25' })
-    ).toBe('Pedestrian start must be less than end');
+    expect(validateCycle({ ...base, pedStart: '25', pedEnd: '25' })).toBe(
+      'Pedestrian start must be less than end',
+    );
   });
 
   test('passes for valid data', () => {

--- a/src/domain/__tests__/matching.test.ts
+++ b/src/domain/__tests__/matching.test.ts
@@ -21,7 +21,7 @@ describe('projectLightsToRoute', () => {
 
   it('filters and sorts lights along route', () => {
     const res = projectLightsToRoute(lights, route);
-    expect(res.map(r => r.light.id)).toEqual(['1', '2']);
+    expect(res.map((r) => r.light.id)).toEqual(['1', '2']);
     expect(res[0].order_m).toBeLessThan(res[1].order_m);
     expect(res[0].dist_m).toBeLessThan(70);
   });

--- a/src/features/navigation/services/ors.test.ts
+++ b/src/features/navigation/services/ors.test.ts
@@ -40,7 +40,12 @@ describe('getRoute', () => {
     const json = {
       features: [
         {
-          geometry: { coordinates: [[2, 1], [4, 3]] },
+          geometry: {
+            coordinates: [
+              [2, 1],
+              [4, 3],
+            ],
+          },
           properties: {
             summary: { distance: 100, duration: 200 },
             segments: [
@@ -62,7 +67,7 @@ describe('getRoute', () => {
     };
     const fetchSpy = jest
       .spyOn(network, 'fetchWithTimeout')
-      .mockResolvedValue({ json: async () => json } as any);
+      .mockResolvedValue({ json: async () => json } as unknown as Response);
 
     const route = await getRoute(start, end);
 

--- a/src/features/navigation/ui/DrivingHUD.tsx
+++ b/src/features/navigation/ui/DrivingHUD.tsx
@@ -3,10 +3,7 @@ import { SafeAreaView, View, Text, StyleSheet } from 'react-native';
 import * as Speech from 'expo-speech';
 import i18n from '../../../i18n';
 import { usePremium } from '../../../premium/subscription';
-import {
-  PremiumFeature,
-  requiresPremium,
-} from '../../../premium/features';
+import { PremiumFeature, requiresPremium } from '../../../premium/features';
 import { speechEnabled } from '../../../state/speech';
 
 export interface DrivingHUDProps {
@@ -65,7 +62,9 @@ export default function DrivingHUD({
         </View>
       ) : null}
       <View style={styles.streetPanel}>
-        <Text testID="hud-street" style={styles.text}>{street}</Text>
+        <Text testID="hud-street" style={styles.text}>
+          {street}
+        </Text>
       </View>
       <View style={styles.etaPanel}>
         <Text testID="hud-eta" style={styles.text}>

--- a/src/features/navigation/ui/SpeedBanner.tsx
+++ b/src/features/navigation/ui/SpeedBanner.tsx
@@ -8,7 +8,11 @@ export interface SpeedBannerProps {
   timeToWindow?: number;
 }
 
-export default function SpeedBanner({ speed, nearestDist, timeToWindow }: SpeedBannerProps) {
+export default function SpeedBanner({
+  speed,
+  nearestDist,
+  timeToWindow,
+}: SpeedBannerProps) {
   if (!speed) return null;
   return (
     <View style={styles.container} pointerEvents="none">
@@ -23,14 +27,17 @@ export default function SpeedBanner({ speed, nearestDist, timeToWindow }: SpeedB
   );
 }
 
+const BG_COLOR = 'rgba(0,0,0,0.6)';
+const TEXT_COLOR = '#fff';
+
 const styles = StyleSheet.create({
   container: {
+    alignSelf: 'center',
+    backgroundColor: BG_COLOR,
+    borderRadius: 6,
+    padding: 8,
     position: 'absolute',
     top: 40,
-    alignSelf: 'center',
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    padding: 8,
-    borderRadius: 6,
   },
-  text: { color: '#fff' },
+  text: { color: TEXT_COLOR },
 });

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,19 +1,4 @@
-let FileSystem: any;
-let fs: typeof import('fs') | null = null;
-let path: typeof import('path') | null = null;
-
-try {
-  FileSystem = require('expo-file-system');
-} catch {
-  fs = require('fs');
-  path = require('path');
-}
-
 export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
-
-const logFile = FileSystem
-  ? `${FileSystem.documentDirectory}data/app.log`
-  : path!.join('data', 'app.log');
 
 function pad(n: number): string {
   return n.toString().padStart(2, '0');
@@ -25,27 +10,25 @@ function formatDate(d: Date): string {
   )}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
 }
 
-async function ensureDir(file: string): Promise<void> {
-  if (FileSystem) {
+export async function log(level: LogLevel, message: string): Promise<void> {
+  const line = `${formatDate(new Date())} [${level}] ${message}\n`;
+  try {
+    const FileSystem = await import('expo-file-system');
+    const file = `${FileSystem.documentDirectory}data/app.log`;
     const dir = `${FileSystem.documentDirectory}data`;
     await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
-  } else if (fs && path) {
+    await FileSystem.writeAsStringAsync(file, line, {
+      encoding: FileSystem.EncodingType.UTF8,
+      append: true,
+    } as import('expo-file-system').WritingOptions & { append: boolean });
+  } catch {
+    const fs = await import('fs');
+    const path = await import('path');
+    const file = path.join('data', 'app.log');
     const dir = path.dirname(file);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
-  }
-}
-
-export async function log(level: LogLevel, message: string): Promise<void> {
-  const line = `${formatDate(new Date())} [${level}] ${message}\n`;
-  await ensureDir(logFile);
-  if (FileSystem) {
-    await FileSystem.writeAsStringAsync(logFile, line, {
-      encoding: FileSystem.EncodingType.UTF8,
-      append: true,
-    });
-  } else if (fs) {
-    fs.appendFileSync(logFile, line);
+    fs.appendFileSync(file, line);
   }
 }


### PR DESCRIPTION
## Summary
- document recent work in CHANGELOG
- link changelog from README and AGENTS
- clean lint warnings and improve logger typings

## Testing
- `npm test -- --coverage`
- `npm run lint -- --format unix` *(fails: existing warnings in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68b005e84da48323b8767bc3ec9045a4