### PR TITLE
test: verify Expo logger

### DIFF
--- a/src/services/tests/logger.test.ts
+++ b/src/services/tests/logger.test.ts
@@ -1,5 +1,12 @@
 import path from 'path';
 
+jest.mock('expo-file-system', () => ({
+  writeAsStringAsync: jest.fn(),
+  makeDirectoryAsync: jest.fn(),
+  documentDirectory: '/doc/',
+  EncodingType: { UTF8: 'utf8' },
+}));
+
 describe('log', () => {
   const fixed = new Date(Date.UTC(2023, 0, 2, 3, 4, 5));
 
@@ -13,7 +20,28 @@ describe('log', () => {
     jest.clearAllMocks();
   });
 
+  it('appends formatted line with expo-file-system', async () => {
+    const { log } = await import('../logger');
+    const FileSystem = await import('expo-file-system');
+    await log('INFO', 'hello');
+    expect(FileSystem.makeDirectoryAsync).toHaveBeenCalledWith('/doc/data', {
+      intermediates: true,
+    });
+    expect(FileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+      `${FileSystem.documentDirectory}data/app.log`,
+      '2023-01-02 03:04:05 [INFO] hello\n',
+      {
+        encoding: FileSystem.EncodingType.UTF8,
+        append: true,
+      },
+    );
+  });
+
   it('appends formatted line with fs', async () => {
+    const FileSystem = await import('expo-file-system');
+    (FileSystem.writeAsStringAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('fail'),
+    );
     jest.mock('fs', () => ({
       appendFileSync: jest.fn(),
       existsSync: jest.fn().mockReturnValue(true),


### PR DESCRIPTION
## Summary
- test logging via expo-file-system

## Testing
- `pre-commit run --files src/services/tests/logger.test.ts`
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any, etc.)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b00fe0b88c8323a284e12a7778514e