### PR TITLE
chore: ignore egg-info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ ios/Pods/
 *.pb
 *.tflite
 
+# --- Python packaging ---
+*.egg-info/
+
 # --- Flutter leftovers / IDE ---
 .dart_tool/
 .flutter-plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025-08
 
+- chore: remove stray `UNKNOWN.egg-info` directory and ignore Python packaging artifacts
 - fix: handle empty lights array to preserve recommendations when no lights are present
 - docs: hyphenate the term traffic-light for consistency
 - feat: add speech guidance for maneuvers

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Removed stray `UNKNOWN.egg-info` directory and ignored Python packaging artifacts.
 - Extracted light detection into `useLightDetector` hook and cycle upload into `lightCycleUploader` service.
 - Retain previous recommendation when no traffic lights are on the route.
 - Introduced navigation factory helpers for modular routing and easier tests.


### PR DESCRIPTION
## Summary
- ignore egg-info folders and delete stray UNKNOWN.egg-info
- document cleanup in README and CHANGELOG

## Testing
- `pre-commit run --files .gitignore README.md CHANGELOG.md`
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any, Color literal issues, etc.)*
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b024d7dbec8323bf6c1b7ca8271a14