### PR TITLE
test: expand coverage and refactor navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2025-08
 
+- refactor: convert remaining `.js` files to `.ts`/`.tsx` and add `tsx` loader
+- chore: refine navigation initialization for improved testability
+- feat: scaffold command and data layers
 - feat: centralize command, processor, source, and store interfaces
 - chore: remove stray `UNKNOWN.egg-info` directory and ignore Python packaging artifacts
 - fix: handle empty lights array to preserve recommendations when no lights are present

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Converted remaining `.js` files to TypeScript and configured the `tsx` loader for Node scripts.
 - Exported additional types and removed legacy interface stubs.
 - Centralized interface exports under `src/interfaces/index.ts`.
 - Added scaffolding for commands, processors, sources, and stores with shared interfaces.

--- a/src/features/navigation/__tests__/getNearestInfo.test.ts
+++ b/src/features/navigation/__tests__/getNearestInfo.test.ts
@@ -47,4 +47,20 @@ describe('getNearestInfo', () => {
     expect(nearestInfo).toEqual({ dist: 0, time: 0 });
     expect(nearestStillGreen).toBe(false);
   });
+
+  it('handles undefined nearest', () => {
+    const { nearestInfo, nearestStillGreen } = getNearestInfo(undefined, 50, 0);
+    expect(nearestInfo).toEqual({ dist: 0, time: 0 });
+    expect(nearestStillGreen).toBe(false);
+  });
+
+  it('handles negative recommended speed', () => {
+    const { nearestInfo, nearestStillGreen } = getNearestInfo(
+      { light, cycle, dist_m: 500, dirForDriver: 'MAIN' },
+      -10,
+      0,
+    );
+    expect(nearestInfo).toEqual({ dist: 0, time: 0 });
+    expect(nearestStillGreen).toBe(false);
+  });
 });

--- a/src/features/navigation/ui/__tests__/DrivingHUD.test.tsx
+++ b/src/features/navigation/ui/__tests__/DrivingHUD.test.tsx
@@ -27,9 +27,11 @@ describe('DrivingHUD', () => {
         eta={60}
         speed={30}
         speedLimit={50}
-      />
+      />,
     );
-    expect(getByTestId('hud-maneuver').props.children).toBe('Turn left in 100 m');
+    expect(getByTestId('hud-maneuver').props.children).toBe(
+      'Turn left in 100 m',
+    );
     expect(getByTestId('hud-street').props.children).toBe('Main St');
     expect(getByTestId('hud-eta').props.children).toBe('ETA: 60s');
     expect(getByTestId('hud-speed-limit').props.children).toBe('Limit: 50');
@@ -37,7 +39,13 @@ describe('DrivingHUD', () => {
 
   it('speaks maneuver when enabled', async () => {
     render(
-      <DrivingHUD maneuver="Turn left" distance={100} street="" eta={0} speed={0} />,
+      <DrivingHUD
+        maneuver="Turn left"
+        distance={100}
+        street=""
+        eta={0}
+        speed={0}
+      />,
     );
     await waitFor(() =>
       expect(Speech.speak).toHaveBeenCalledWith('Turn left in 100 m'),

--- a/src/features/navigation/ui/__tests__/SpeedBanner.test.tsx
+++ b/src/features/navigation/ui/__tests__/SpeedBanner.test.tsx
@@ -13,10 +13,10 @@ import SpeedBanner from '../SpeedBanner';
 describe('SpeedBanner', () => {
   it('renders recommendation text', () => {
     const { getByText } = render(
-      <SpeedBanner speed={30} nearestDist={100} timeToWindow={20} />
+      <SpeedBanner speed={30} nearestDist={100} timeToWindow={20} />,
     );
     expect(
-      getByText('Recommended 30 km/h • next light in 100 m • window in 20 s')
+      getByText('Recommended 30 km/h • next light in 100 m • window in 20 s'),
     ).toBeTruthy();
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import {
   createNavigation,
+  createNavigationFactory,
   initialState,
   resolveNavigationDeps,
   defaultNavigationDeps,
@@ -29,6 +30,14 @@ describe('index facade', () => {
   it('allows injecting handlers', () => {
     const custom = jest.fn();
     const nav = createNavigation(undefined, { handleStartNavigation: custom });
+    nav.handleStartNavigation(jest.fn());
+    expect(custom).toHaveBeenCalled();
+  });
+
+  it('creates factory with injected deps', () => {
+    const custom = jest.fn();
+    const factory = createNavigationFactory({ handleStartNavigation: custom });
+    const nav = factory();
     nav.handleStartNavigation(jest.fn());
     expect(custom).toHaveBeenCalled();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,15 +35,23 @@ export function resolveNavigationDeps(
   };
 }
 
-export function createNavigation(
-  state: NavigationState = initialState,
-  deps: Partial<NavigationDeps> = {},
-) {
+export function createNavigationFactory(deps: Partial<NavigationDeps> = {}): (
+  state?: NavigationState,
+) => {
+  initialState: NavigationState;
+} & NavigationDeps {
   const resolved = resolveNavigationDeps(deps);
-  return {
+  return (state: NavigationState = initialState) => ({
     ...resolved,
     initialState: { ...state },
-  };
+  });
+}
+
+export function createNavigation(
+  state?: NavigationState,
+  deps: Partial<NavigationDeps> = {},
+) {
+  return createNavigationFactory(deps)(state);
 }
 
 export {

--- a/src/premium/subscription.ts
+++ b/src/premium/subscription.ts
@@ -16,7 +16,9 @@ export function usePremium() {
       try {
         await InAppPurchases.connectAsync();
         const history = await InAppPurchases.getPurchaseHistoryAsync();
-        const active = history.results?.some(r => r.productId === SUBSCRIPTION_ID);
+        const active = history.results?.some(
+          (r) => r.productId === SUBSCRIPTION_ID,
+        );
         if (mounted) setPremium(!!active);
       } catch (e) {
         console.warn('IAP error', e);

--- a/src/services/__tests__/uploadLightData.test.ts
+++ b/src/services/__tests__/uploadLightData.test.ts
@@ -1,0 +1,19 @@
+jest.mock('../supabase', () => ({
+  supabase: { from: jest.fn() },
+}));
+jest.mock('../logger', () => ({ log: jest.fn() }));
+
+import { uploadCycle } from '../uploadLightData';
+import { supabase } from '../supabase';
+import { log } from '../logger';
+
+describe('uploadCycle', () => {
+  it('logs and throws on insert error', async () => {
+    const error = new Error('bad');
+    (supabase.from as jest.Mock).mockReturnValueOnce({
+      insert: jest.fn().mockResolvedValue({ error }),
+    });
+    await expect(uploadCycle(1, 2, 3, [])).rejects.toThrow('bad');
+    expect(log).toHaveBeenCalledWith('ERROR', 'Failed to upload cycle: bad');
+  });
+});

--- a/src/state/speech.test.ts
+++ b/src/state/speech.test.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { speechEnabled, setSpeechEnabled, loadSpeechEnabled } from './speech';
+import * as speech from './speech';
+const { setSpeechEnabled, loadSpeechEnabled } = speech;
 
 jest.mock('@react-native-async-storage/async-storage', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -14,11 +15,17 @@ describe('speech state', () => {
   it('loads flag from storage', async () => {
     await AsyncStorage.setItem('speech_enabled', '0');
     await loadSpeechEnabled();
-    expect(speechEnabled).toBe(false);
+    expect(speech.speechEnabled).toBe(false);
   });
 
   it('saves flag to storage', async () => {
     await setSpeechEnabled(false);
     expect(await AsyncStorage.getItem('speech_enabled')).toBe('0');
+  });
+
+  it('toggles and persists', async () => {
+    await setSpeechEnabled(false);
+    await setSpeechEnabled(true);
+    expect(await AsyncStorage.getItem('speech_enabled')).toBe('1');
   });
 });

--- a/src/state/theme.test.ts
+++ b/src/state/theme.test.ts
@@ -21,4 +21,11 @@ describe('theme state', () => {
     await setColor('blue');
     expect(await AsyncStorage.getItem('theme_color')).toBe('blue');
   });
+
+  it('propagates storage failure', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(
+      new Error('fail'),
+    );
+    await expect(loadFromStorage()).rejects.toThrow('fail');
+  });
 });


### PR DESCRIPTION
## Summary
- refactor navigation facade to expose `createNavigationFactory`
- cover edge cases for nearest traffic lights, speech and theme persistence
- verify Supabase upload error logging

## Testing
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b030e53bbc83238b30d27cd754c92c