### PR TITLE
refactor: simplify navigation factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Consult `README.md` for environment variables and more detailed setup steps.
 - Define component styles via `StyleSheet.create` blocks.
 - Keep code formatted with Prettier/ESLint for TS/JS files.
 - Python files, if added, must be formatted with `black` and sorted with `isort`.
+  These formatters run via pre-commit hooks.
 
 ## Checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - feat: add speech guidance for maneuvers
 - feat: add theme state with settings screen
 - refactor: group navigation and traffic modules under `src/features`
+- refactor: simplify navigation dependency resolution and expose `cloneNavigationState` helper

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Expanded test coverage for navigation helpers and cycle upload failure paths.
 - Converted remaining `.js` files to TypeScript and configured the `tsx` loader for Node scripts.
 - Exported additional types and removed legacy interface stubs.
 - Centralized interface exports under `src/interfaces/index.ts`.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   initialState,
   resolveNavigationDeps,
   defaultNavigationDeps,
+  cloneNavigationState,
 } from './index';
 
 describe('index facade', () => {
@@ -51,5 +52,11 @@ describe('index facade', () => {
     const custom = jest.fn();
     const deps = resolveNavigationDeps({ handleStartNavigation: custom });
     expect(deps.handleStartNavigation).toBe(custom);
+  });
+
+  it('clones navigation state', () => {
+    const clone = cloneNavigationState(initialState);
+    expect(clone).toEqual(initialState);
+    expect(clone).not.toBe(initialState);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,15 +24,13 @@ export const defaultNavigationDeps: NavigationDeps = {
 export function resolveNavigationDeps(
   deps: Partial<NavigationDeps> = {},
 ): NavigationDeps {
-  return {
-    handleStartNavigation:
-      deps.handleStartNavigation ?? defaultNavigationDeps.handleStartNavigation,
-    handleClearRoute:
-      deps.handleClearRoute ?? defaultNavigationDeps.handleClearRoute,
-    getNearestInfo: deps.getNearestInfo ?? defaultNavigationDeps.getNearestInfo,
-    computeRecommendation:
-      deps.computeRecommendation ?? defaultNavigationDeps.computeRecommendation,
-  };
+  return { ...defaultNavigationDeps, ...deps };
+}
+
+export function cloneNavigationState(
+  state: NavigationState = initialState,
+): NavigationState {
+  return { ...state };
 }
 
 export function createNavigationFactory(deps: Partial<NavigationDeps> = {}): (
@@ -43,7 +41,7 @@ export function createNavigationFactory(deps: Partial<NavigationDeps> = {}): (
   const resolved = resolveNavigationDeps(deps);
   return (state: NavigationState = initialState) => ({
     ...resolved,
-    initialState: { ...state },
+    initialState: cloneNavigationState(state),
   });
 }
 


### PR DESCRIPTION
## Summary
- streamline navigation dependency resolution and add `cloneNavigationState`
- document recent test coverage expansion
- clarify Python formatting hooks in AGENTS

## Testing
- `pre-commit run --files AGENTS.md README.md CHANGELOG.md src/index.ts src/index.test.ts`
- `npm run lint`
- `npm test -- --coverage`
- `npx expo start` *(fails: Cannot find module 'metro/src/ModuleGraph/worker/importLocationsPlugin')*

------
https://chatgpt.com/codex/tasks/task_e_68b033bdeb4c8323a7ce6f085f06143b