### PR TITLE
refactor: deep clone navigation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 ## Recent changes
 
 - Split map and menu UI into `MapViewWrapper` and `MenuContainer` components with hooks for Supabase data and menu state.
+- Exposed `cloneNavigationState` to deep copy navigation state and allow custom initial state injection.
 - Renamed service interfaces to `SupabaseService` and `AnalyticsService`.
 - Expanded test coverage for navigation helpers and cycle upload failure paths.
 - Converted remaining `.js` files to TypeScript and configured the `tsx` loader for Node scripts.

--- a/src/features/navigation/cloneNavigationState.ts
+++ b/src/features/navigation/cloneNavigationState.ts
@@ -1,0 +1,4 @@
+import type { NavigationState } from './index';
+
+export const cloneNavigationState = (state: NavigationState): NavigationState =>
+  JSON.parse(JSON.stringify(state));

--- a/src/features/navigation/index.test.ts
+++ b/src/features/navigation/index.test.ts
@@ -1,4 +1,10 @@
-import { handleStartNavigation, handleClearRoute, initialState } from './index';
+import type { NavigationState } from './index';
+import {
+  handleStartNavigation,
+  handleClearRoute,
+  initialState,
+  cloneNavigationState,
+} from './index';
 
 describe('navigation helpers', () => {
   it('tracks start navigation', () => {
@@ -7,9 +13,22 @@ describe('navigation helpers', () => {
     expect(track).toHaveBeenCalledWith('navigation_start');
   });
 
-  it('returns cleared state', () => {
-    const state = handleClearRoute();
-    expect(state).toEqual(initialState);
-    expect(state).not.toBe(initialState);
+  it('deep clones navigation state', () => {
+    const copy = cloneNavigationState(initialState);
+    copy.hudInfo.street = 'foo';
+    expect(initialState.hudInfo.street).toBe('');
+  });
+
+  it('returns cloned custom state', () => {
+    const custom: NavigationState = {
+      ...initialState,
+      hudInfo: { ...initialState.hudInfo, street: 'Main' },
+      steps: [{ id: 1 }],
+    };
+    const state = handleClearRoute(custom);
+    expect(state).toEqual(custom);
+    expect(state).not.toBe(custom);
+    state.hudInfo.street = 'Other';
+    expect(custom.hudInfo.street).toBe('Main');
   });
 });

--- a/src/features/navigation/index.ts
+++ b/src/features/navigation/index.ts
@@ -1,4 +1,5 @@
 import type { Direction, Light, LightCycle } from '../../domain/types';
+import { cloneNavigationState } from './cloneNavigationState';
 
 export const handleStartNavigation = (track: (event: string) => void): void => {
   track('navigation_start');
@@ -36,12 +37,9 @@ export const initialState: NavigationState = {
   menuVisible: false,
 };
 
-export const handleClearRoute = (): NavigationState => ({
-  ...initialState,
-  hudInfo: { ...initialState.hudInfo },
-  lightsOnRoute: [],
-  nearestInfo: { ...initialState.nearestInfo },
-});
+export const handleClearRoute = (
+  state: NavigationState = initialState,
+): NavigationState => cloneNavigationState(state);
 
 export interface LightOnRoute {
   light: Light;
@@ -52,3 +50,4 @@ export interface LightOnRoute {
 
 export { getNearestInfo } from './getNearestInfo';
 export { computeRecommendation } from './computeRecommendation';
+export { cloneNavigationState } from './cloneNavigationState';


### PR DESCRIPTION
## Summary
- add `cloneNavigationState` helper for deep copying
- allow `handleClearRoute` to clone custom initial state
- document helper in README and cover with tests

## Testing
- `pre-commit run --files src/features/navigation/index.ts src/features/navigation/cloneNavigationState.ts src/features/navigation/index.test.ts README.md`
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b045716ff483239add8b3fb6cfa4c4