### PR TITLE
ci: upload coverage to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test -- --coverage
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
-          files: ./coverage/lcov.info
+          files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ npm run lint
 npm test -- --coverage
 ```
 
-Tests should pass and formatting hooks should run on the changed files.
+Tests should pass and formatting hooks should run on the changed files. The `test` workflow uploads `coverage/lcov.info` to Codecov.
 
 ## For New Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # greenwave-rn
 
+[![codecov](https://codecov.io/gh/maxshmax666/greenWave/branch/main/graph/badge.svg)](https://codecov.io/gh/maxshmax666/greenWave)
+
 React Native (Expo) app with real-time traffic-light detection, premium subscriptions, and analytics.
 
 ## Recent changes
 
+- Added GitHub Actions test workflow with Codecov coverage uploads.
 - Split map and menu UI into `MapViewWrapper` and `MenuContainer` components with hooks for Supabase data and menu state.
 - Exposed `cloneNavigationState` to deep copy navigation state and allow custom initial state injection.
 - Renamed service interfaces to `SupabaseService` and `AnalyticsService`.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,14 +30,18 @@ describe('index facade', () => {
 
   it('allows injecting handlers', () => {
     const custom = jest.fn();
-    const nav = createNavigation(undefined, { handleStartNavigation: custom });
+    const nav = createNavigation(undefined, {
+      deps: { handleStartNavigation: custom },
+    });
     nav.handleStartNavigation(jest.fn());
     expect(custom).toHaveBeenCalled();
   });
 
   it('creates factory with injected deps', () => {
     const custom = jest.fn();
-    const factory = createNavigationFactory({ handleStartNavigation: custom });
+    const factory = createNavigationFactory({
+      deps: { handleStartNavigation: custom },
+    });
     const nav = factory();
     nav.handleStartNavigation(jest.fn());
     expect(custom).toHaveBeenCalled();
@@ -58,5 +62,12 @@ describe('index facade', () => {
     const clone = cloneNavigationState(initialState);
     expect(clone).toEqual(initialState);
     expect(clone).not.toBe(initialState);
+  });
+
+  it('allows custom state cloning', () => {
+    const customClone = jest.fn().mockReturnValue(initialState);
+    const nav = createNavigation(undefined, { cloneState: customClone });
+    expect(customClone).toHaveBeenCalled();
+    expect(nav.initialState).toEqual(initialState);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,25 +33,31 @@ export function cloneNavigationState(
   return { ...state };
 }
 
+export interface NavigationConfig {
+  deps?: Partial<NavigationDeps>;
+  cloneState?: (state: NavigationState) => NavigationState;
+}
+
 export type NavigationFactory = (
   state?: NavigationState,
 ) => { initialState: NavigationState } & NavigationDeps;
 
 export function createNavigationFactory(
-  deps: Partial<NavigationDeps> = {},
+  config: NavigationConfig = {},
 ): NavigationFactory {
-  const resolved = resolveNavigationDeps(deps);
+  const resolved = resolveNavigationDeps(config.deps);
+  const clone = config.cloneState ?? cloneNavigationState;
   return (state: NavigationState = initialState) => ({
     ...resolved,
-    initialState: cloneNavigationState(state),
+    initialState: clone(state),
   });
 }
 
 export function createNavigation(
   state?: NavigationState,
-  deps: Partial<NavigationDeps> = {},
+  config: NavigationConfig = {},
 ) {
-  return createNavigationFactory(deps)(state);
+  return createNavigationFactory(config)(state);
 }
 
 export {


### PR DESCRIPTION
## Summary
- upload lcov coverage to Codecov
- inject clone function into navigation factory and cover new behavior
- show Codecov badge in README

## Testing
- `pre-commit run --files .github/workflows/test.yml README.md AGENTS.md src/index.ts src/index.test.ts` *(fails: command not found)*
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b04c504c588323aa98c052133e4b3c