### PR TITLE
test: cover logger output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Run unit tests:
 npm test -- --coverage
 ```
 
+### Debugging
+
+Write debug messages to `data/app.log` with the logger:
+
+```ts
+import { log } from './src/services/logger';
+
+await log('INFO', 'App started');
+```
+
+Each line follows `YYYY-MM-DD HH:MM:SS [LEVEL] message`.
+
 ### Voice phase logger
 
 On the traffic screen, tap the record button and speak a color followed by its start time (e.g., "green 12").

--- a/src/services/__tests__/logger.test.ts
+++ b/src/services/__tests__/logger.test.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import { log } from '../logger';
+
+describe('logger', () => {
+  const file = 'data/app.log';
+
+  beforeEach(() => {
+    fs.rmSync('data', { recursive: true, force: true });
+  });
+
+  it('writes formatted log line', async () => {
+    await log('INFO', 'test message');
+    const content = fs.readFileSync(file, 'utf8').trim();
+    const line = content.split('\n').pop();
+    expect(line).toMatch(
+      /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \[INFO\] test message/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add logger unit test covering timestamp format
- document debugging via file logger

## Testing
- `pre-commit run --files README.md src/services/__tests__/logger.test.ts`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b04e638cdc8323ba39fd32e5f276f4