### PR TITLE
refactor navigation factory and add config types

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 ## Recent changes
 
 - Added GitHub Actions test workflow with Codecov coverage uploads.
+- Split navigation factory into a dedicated `navigationFactory` module for easier testing.
+- Added typed configuration objects for Supabase and analytics services.
+- Exposed command, processor, source, and store interfaces via directory `index.ts` files.
 - Split map and menu UI into `MapViewWrapper` and `MenuContainer` components with hooks for Supabase data and menu state.
 - Exposed `cloneNavigationState` to deep copy navigation state and allow custom initial state injection.
 - Renamed service interfaces to `SupabaseService` and `AnalyticsService`.
@@ -107,3 +110,11 @@ To create a debug Android APK:
 ```
 npm run apk:debug
 ```
+
+## TypeScript migration plan
+
+- Adopt TypeScript incrementally; new files use `strictNullChecks`.
+- Expose interfaces from each module's `index.ts` to guide refactors.
+- Supabase and analytics services accept typed config objects.
+- Use the `tsx` loader directly without a build step.
+- Ensure `npm test -- --coverage` and `npm run lint` pass after each change.

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { Command, CliCommand, VoiceCommand } from '../interfaces/commands';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,75 +1,4 @@
-import {
-  handleStartNavigation,
-  handleClearRoute,
-  initialState,
-  getNearestInfo,
-  computeRecommendation,
-} from './features/navigation';
-import type { NavigationState, LightOnRoute } from './features/navigation';
-
-export interface NavigationDeps {
-  handleStartNavigation: typeof handleStartNavigation;
-  handleClearRoute: typeof handleClearRoute;
-  getNearestInfo: typeof getNearestInfo;
-  computeRecommendation: typeof computeRecommendation;
-}
-
-export const defaultNavigationDeps: NavigationDeps = {
-  handleStartNavigation,
-  handleClearRoute,
-  getNearestInfo,
-  computeRecommendation,
-};
-
-export function resolveNavigationDeps(
-  deps: Partial<NavigationDeps> = {},
-): NavigationDeps {
-  return { ...defaultNavigationDeps, ...deps };
-}
-
-export function cloneNavigationState(
-  state: NavigationState = initialState,
-): NavigationState {
-  return { ...state };
-}
-
-export interface NavigationConfig {
-  deps?: Partial<NavigationDeps>;
-  cloneState?: (state: NavigationState) => NavigationState;
-}
-
-export type NavigationFactory = (
-  state?: NavigationState,
-) => { initialState: NavigationState } & NavigationDeps;
-
-export function createNavigationFactory(
-  config: NavigationConfig = {},
-): NavigationFactory {
-  const resolved = resolveNavigationDeps(config.deps);
-  const clone = config.cloneState ?? cloneNavigationState;
-  return (state: NavigationState = initialState) => ({
-    ...resolved,
-    initialState: clone(state),
-  });
-}
-
-export function createNavigation(
-  state?: NavigationState,
-  config: NavigationConfig = {},
-) {
-  return createNavigationFactory(config)(state);
-}
-
-export {
-  handleStartNavigation,
-  handleClearRoute,
-  initialState,
-  getNearestInfo,
-  computeRecommendation,
-  type NavigationState,
-  type LightOnRoute,
-};
-
+export * from './navigationFactory';
 export * from './commands';
 export * from './processors';
 export * from './sources';
@@ -82,4 +11,6 @@ export type {
   GroupedProcessor,
   Source,
   Store,
+  SupabaseConfig,
+  AnalyticsConfig,
 } from './interfaces';

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -1,0 +1,8 @@
+export interface SupabaseConfig {
+  url: string;
+  anonKey: string;
+}
+
+export interface AnalyticsConfig {
+  disabled?: boolean;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -8,3 +8,4 @@ export type { Network } from './network';
 export type { Notifications, PhaseEmitter } from './notifications';
 export type { PhaseSync, PhaseRecord } from './phaseSync';
 export type { SupabaseService } from './supabaseService';
+export type { SupabaseConfig, AnalyticsConfig } from './config';

--- a/src/navigationFactory.test.ts
+++ b/src/navigationFactory.test.ts
@@ -5,9 +5,9 @@ import {
   resolveNavigationDeps,
   defaultNavigationDeps,
   cloneNavigationState,
-} from './index';
+} from './navigationFactory';
 
-describe('index facade', () => {
+describe('navigationFactory', () => {
   it('creates navigation helpers', () => {
     const nav = createNavigation();
     const track = jest.fn();

--- a/src/navigationFactory.ts
+++ b/src/navigationFactory.ts
@@ -1,0 +1,71 @@
+import {
+  handleStartNavigation,
+  handleClearRoute,
+  initialState,
+  getNearestInfo,
+  computeRecommendation,
+} from './features/navigation';
+import type { NavigationState, LightOnRoute } from './features/navigation';
+
+export interface NavigationDeps {
+  handleStartNavigation: typeof handleStartNavigation;
+  handleClearRoute: typeof handleClearRoute;
+  getNearestInfo: typeof getNearestInfo;
+  computeRecommendation: typeof computeRecommendation;
+}
+
+export const defaultNavigationDeps: NavigationDeps = {
+  handleStartNavigation,
+  handleClearRoute,
+  getNearestInfo,
+  computeRecommendation,
+};
+
+export function resolveNavigationDeps(
+  deps: Partial<NavigationDeps> = {},
+): NavigationDeps {
+  return { ...defaultNavigationDeps, ...deps };
+}
+
+export function cloneNavigationState(
+  state: NavigationState = initialState,
+): NavigationState {
+  return { ...state };
+}
+
+export interface NavigationConfig {
+  deps?: Partial<NavigationDeps>;
+  cloneState?: (state: NavigationState) => NavigationState;
+}
+
+export type NavigationFactory = (
+  state?: NavigationState,
+) => { initialState: NavigationState } & NavigationDeps;
+
+export function createNavigationFactory(
+  config: NavigationConfig = {},
+): NavigationFactory {
+  const resolved = resolveNavigationDeps(config.deps);
+  const clone = config.cloneState ?? cloneNavigationState;
+  return (state: NavigationState = initialState) => ({
+    ...resolved,
+    initialState: clone(state),
+  });
+}
+
+export function createNavigation(
+  state?: NavigationState,
+  config: NavigationConfig = {},
+) {
+  return createNavigationFactory(config)(state);
+}
+
+export {
+  handleStartNavigation,
+  handleClearRoute,
+  initialState,
+  getNearestInfo,
+  computeRecommendation,
+  type NavigationState,
+  type LightOnRoute,
+};

--- a/src/processors/grouped/index.ts
+++ b/src/processors/grouped/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { GroupedProcessor } from '../../interfaces/processors/grouped';

--- a/src/processors/index.ts
+++ b/src/processors/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { Processor } from '../interfaces/processors';

--- a/src/services/__tests__/analytics.test.ts
+++ b/src/services/__tests__/analytics.test.ts
@@ -1,11 +1,20 @@
-import { trackEvent } from '../analytics';
+import { createAnalytics } from '../analytics';
 import { logEvent } from '@react-native-firebase/analytics';
 
 jest.mock('@react-native-firebase/analytics');
 
 describe('analytics service', () => {
+  beforeEach(() => jest.clearAllMocks());
+
   it('logs events via firebase', async () => {
-    await trackEvent('foo', { bar: 'baz' });
+    const analytics = createAnalytics();
+    await analytics.trackEvent('foo', { bar: 'baz' });
     expect(logEvent).toHaveBeenCalledWith('foo', { bar: 'baz' });
+  });
+
+  it('skips logging when disabled', async () => {
+    const analytics = createAnalytics({ disabled: true });
+    await analytics.trackEvent('foo', { bar: 'baz' });
+    expect(logEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,15 +1,22 @@
 import firebaseAnalytics from '@react-native-firebase/analytics';
 import { log } from './logger';
 import type { AnalyticsService } from '../interfaces/analyticsService';
+import type { AnalyticsConfig } from '../interfaces/config';
 
-export const analytics: AnalyticsService = {
-  async trackEvent(name, params) {
-    try {
-      await firebaseAnalytics().logEvent(name, params);
-    } catch (err) {
-      await log('WARN', `Failed to log analytics event: ${String(err)}`);
-    }
-  },
-};
+export function createAnalytics(
+  config: AnalyticsConfig = {},
+): AnalyticsService {
+  return {
+    async trackEvent(name, params) {
+      if (config.disabled) return;
+      try {
+        await firebaseAnalytics().logEvent(name, params);
+      } catch (err) {
+        await log('WARN', `Failed to log analytics event: ${String(err)}`);
+      }
+    },
+  };
+}
 
+export const analytics = createAnalytics();
 export const trackEvent = analytics.trackEvent;

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -8,17 +8,20 @@ import { network } from './network';
 import { log } from './logger';
 import type { Light, LightCycle } from '../domain/types';
 import type { SupabaseService } from '../interfaces/supabaseService';
+import type { SupabaseConfig } from '../interfaces/config';
 
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
-const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '';
-
-export const supabase: SupabaseClient = createClient(
-  SUPABASE_URL,
-  SUPABASE_ANON_KEY,
-  {
+export function createSupabaseClient(config: SupabaseConfig): SupabaseClient {
+  return createClient(config.url, config.anonKey, {
     global: { fetch: network.fetchWithTimeout },
-  },
-);
+  });
+}
+
+const defaultConfig: SupabaseConfig = {
+  url: process.env.EXPO_PUBLIC_SUPABASE_URL ?? '',
+  anonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '',
+};
+
+export const supabase = createSupabaseClient(defaultConfig);
 
 async function fetchLightsAndCycles(): Promise<{
   lights: Light[];

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { Source } from '../interfaces/sources';

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,1 +1,1 @@
-export {};
+export type { Store } from '../interfaces/stores';


### PR DESCRIPTION
## Summary
- extract navigation factory into standalone module and re-export from index
- expose module interfaces via index files
- add typed config objects for Supabase and analytics services
- expand analytics tests and document TypeScript migration plan

## Testing
- `npx eslint src --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b05127d68c8323b23dac2437f77a60