### PR TITLE
feat: add onMessage service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Introduced `onMessage` service with dedicated parsing, validation, and handling helpers.
 - Added GitHub Actions test workflow with Codecov coverage uploads.
 - Split navigation factory into a dedicated `navigationFactory` module for easier testing.
 - Added typed configuration objects for Supabase and analytics services.

--- a/src/services/__tests__/onMessage.test.ts
+++ b/src/services/__tests__/onMessage.test.ts
@@ -1,0 +1,48 @@
+import {
+  parseMessage,
+  validateMessage,
+  handleMessage,
+  onMessage,
+} from '../onMessage';
+import { log } from '../logger';
+
+jest.mock('../logger', () => ({
+  log: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('parseMessage', () => {
+  it('parses JSON string', () => {
+    expect(parseMessage('{"type":"ping"}')).toEqual({ type: 'ping' });
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseMessage('bad')).toThrow();
+  });
+});
+
+describe('validateMessage', () => {
+  it('returns message when type exists', () => {
+    expect(validateMessage({ type: 'ping', payload: 1 })).toEqual({
+      type: 'ping',
+      payload: 1,
+    });
+  });
+
+  it('throws when type missing', () => {
+    expect(() => validateMessage({})).toThrow('Invalid message');
+  });
+});
+
+describe('handleMessage', () => {
+  it('logs received type', async () => {
+    await handleMessage({ type: 'ping' });
+    expect(log).toHaveBeenCalledWith('INFO', 'received ping');
+  });
+});
+
+describe('onMessage', () => {
+  it('runs full pipeline', async () => {
+    await onMessage('{"type":"ping"}');
+    expect(log).toHaveBeenCalledWith('INFO', 'received ping');
+  });
+});

--- a/src/services/onMessage.ts
+++ b/src/services/onMessage.ts
@@ -1,0 +1,34 @@
+import { log } from './logger';
+
+export interface Message {
+  type: string;
+  payload?: unknown;
+}
+
+export function parseMessage(raw: string): unknown {
+  return JSON.parse(raw);
+}
+
+export function validateMessage(data: unknown): Message {
+  if (
+    !data ||
+    typeof data !== 'object' ||
+    Array.isArray(data) ||
+    typeof (data as { type?: unknown }).type !== 'string'
+  ) {
+    throw new Error('Invalid message');
+  }
+  return data as Message;
+}
+
+export async function handleMessage(message: Message): Promise<void> {
+  await log('INFO', `received ${message.type}`);
+}
+
+export async function onMessage(raw: string): Promise<void> {
+  const data = parseMessage(raw);
+  const message = validateMessage(data);
+  await handleMessage(message);
+}
+
+export default onMessage;


### PR DESCRIPTION
## Summary
- document onMessage service
- parse, validate, and handle incoming messages
- test message pipeline

## Testing
- `pre-commit run --files src/services/onMessage.ts src/services/__tests__/onMessage.test.ts README.md`
- `npm run lint`
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b05766d2188323b03585268cf3c59f