### PR TITLE
chore: add coverage npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npx expo start -c
 Run unit tests:
 
 ```
-npm test -- --coverage
+npm run coverage
 ```
 
 ### Debugging

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "web": "expo start --web",
     "test": "node --import tsx node_modules/jest/bin/jest.js",
     "lint": "eslint src",
-    "apk:debug": "npx expo run:android --variant debug"
+    "apk:debug": "npx expo run:android --variant debug",
+    "coverage": "npm test -- --coverage"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.24.0",

--- a/src/ui/__tests__/MapViewWrapper.test.tsx
+++ b/src/ui/__tests__/MapViewWrapper.test.tsx
@@ -10,8 +10,15 @@ jest.mock('react-native', () => ({
 
 jest.mock('react-native-maps', () => ({
   __esModule: true,
-  default: (props: Record<string, unknown> & { children?: React.ReactNode }) =>
-    React.createElement('MapView', props, props.children),
+  default: React.forwardRef<unknown, Record<string, unknown>>(
+    function MockMapView(props, ref) {
+      return React.createElement(
+        'MapView',
+        { ...props, ref },
+        props.children as React.ReactNode,
+      );
+    },
+  ),
   Marker: 'Marker',
   Polyline: 'Polyline',
 }));


### PR DESCRIPTION
## Summary
- add `npm run coverage` for running tests with coverage
- document new coverage command
- fix react-native-maps mock to accept refs

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b05e04cf7c8323a106adac3601de9f