### PR TITLE
chore: configure python formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 24.4.2
     hooks:
       - id: black
+        language_version: python3
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
+        language_version: python3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,9 @@ Consult `README.md` for environment variables and more detailed setup steps.
 - Use functional components with hooks.
 - Define component styles via `StyleSheet.create` blocks.
 - Keep code formatted with Prettier/ESLint for TS/JS files.
-- Python files, if added, must be formatted with `black` and sorted with `isort`.
-  These formatters run via pre-commit hooks.
+- Python files must be formatted with `black` (line length 88, Python 3.11)
+  and imports sorted with `isort` (profile "black", line length 88).
+  Run these via `pre-commit run --files <py_files>` before committing.
 
 ## Checks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,4 @@ target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
+line_length = 88


### PR DESCRIPTION
## Summary
- document Python formatting guidelines
- set up black and isort pre-commit hooks
- configure black and isort in pyproject

## Testing
- `pre-commit run --files temp.py`
- `pre-commit run --files AGENTS.md .pre-commit-config.yaml pyproject.toml`
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm test -- --coverage` *(fails: Cannot find package 'tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68b060e307648323812246dec3fc8153