### PR TITLE
feat(navigation): deep clone state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- `createNavigation` now deep clones state to avoid mutating `hudInfo`.
 - Added coverage script for easier local test runs.
 - Improved map reference mocking in tests.
 - Introduced `onMessage` service with dedicated parsing, validation, and handling helpers.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,19 @@
+import { createNavigation, initialState, cloneNavigationState } from './index';
+
+describe('index navigation facade', () => {
+  it('deep clones navigation state', () => {
+    const clone = cloneNavigationState(initialState);
+    clone.hudInfo.street = 'foo';
+    expect(initialState.hudInfo.street).toBe('');
+  });
+
+  it('createNavigation isolates nested hudInfo', () => {
+    const custom = {
+      ...initialState,
+      hudInfo: { ...initialState.hudInfo, street: 'Main' },
+    };
+    const nav = createNavigation(custom);
+    nav.initialState.hudInfo.street = 'Other';
+    expect(custom.hudInfo.street).toBe('Main');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+import type { NavigationState } from './features/navigation';
+
+export const cloneNavigationState = (state: NavigationState): NavigationState =>
+  JSON.parse(JSON.stringify(state));
+
 export * from './navigationFactory';
 export * from './commands';
 export * from './processors';

--- a/src/navigationFactory.test.ts
+++ b/src/navigationFactory.test.ts
@@ -4,8 +4,8 @@ import {
   initialState,
   resolveNavigationDeps,
   defaultNavigationDeps,
-  cloneNavigationState,
 } from './navigationFactory';
+import { cloneNavigationState } from './index';
 
 describe('navigationFactory', () => {
   it('creates navigation helpers', () => {

--- a/src/navigationFactory.ts
+++ b/src/navigationFactory.ts
@@ -6,6 +6,7 @@ import {
   computeRecommendation,
 } from './features/navigation';
 import type { NavigationState, LightOnRoute } from './features/navigation';
+import { cloneNavigationState } from './index';
 
 export interface NavigationDeps {
   handleStartNavigation: typeof handleStartNavigation;
@@ -25,12 +26,6 @@ export function resolveNavigationDeps(
   deps: Partial<NavigationDeps> = {},
 ): NavigationDeps {
   return { ...defaultNavigationDeps, ...deps };
-}
-
-export function cloneNavigationState(
-  state: NavigationState = initialState,
-): NavigationState {
-  return { ...state };
 }
 
 export interface NavigationConfig {


### PR DESCRIPTION
## Summary
- deep clone navigation state via new `cloneNavigationState`
- ensure `createNavigation` uses deep clone
- test `cloneNavigationState` and README note

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b064feb5b48323b78771ae490bd028