### PR TITLE
docs: standardize test command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Tests live beside the code they verify, and coverage reports are stored under `c
 
 - `npm install` – install dependencies.
 - `npx expo start` – launch the development server.
-- `npm test -- --coverage` – run the Jest suite with coverage.
+- `npm test -- --coverage` – run the Jest suite with coverage (replaces `npm run coverage`).
 - `npm run lint` – check JavaScript and TypeScript code style.
 - Node scripts use the [`tsx`](https://github.com/privatenumber/tsx) loader via `node --loader tsx`.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Dropped coverage npm script; run tests with `npm test -- --coverage`.
 - Re-exported `cloneNavigationState` from the navigation feature and removed duplicate implementation.
 - Renamed project heading to "greenWave".
 - Added tests to ensure navigation maneuvers remain isolated between runs.
@@ -90,7 +91,7 @@ npx expo start -c
 Run unit tests:
 
 ```
-npm run coverage
+npm test -- --coverage
 ```
 
 ### Debugging

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "web": "expo start --web",
     "test": "node --import tsx node_modules/jest/bin/jest.js",
     "lint": "eslint src",
-    "apk:debug": "npx expo run:android --variant debug",
-    "coverage": "npm test -- --coverage"
+    "apk:debug": "npx expo run:android --variant debug"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.24.0",


### PR DESCRIPTION
## Summary
- drop `coverage` npm script
- document `npm test -- --coverage` as the single way to run tests

## Testing
- `pre-commit run --files AGENTS.md README.md package.json`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b08196b9348323ab05ff7132292287