### PR TITLE
test(onMessage): cover invalid json and missing type

### DIFF
--- a/src/services/__tests__/onMessage.test.ts
+++ b/src/services/__tests__/onMessage.test.ts
@@ -41,8 +41,22 @@ describe('handleMessage', () => {
 });
 
 describe('onMessage', () => {
+  beforeEach(() => {
+    (log as jest.Mock).mockClear();
+  });
+
   it('runs full pipeline', async () => {
     await onMessage('{"type":"ping"}');
     expect(log).toHaveBeenCalledWith('INFO', 'received ping');
+  });
+
+  it('throws on invalid JSON and skips logging', async () => {
+    await expect(onMessage('bad')).rejects.toThrow();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('throws on missing type and skips logging', async () => {
+    await expect(onMessage('{}')).rejects.toThrow('Invalid message');
+    expect(log).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- expand onMessage tests to cover invalid JSON and missing type inputs
- ensure errors bubble up without invoking logger

## Testing
- `pre-commit run --files src/services/__tests__/onMessage.test.ts`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b087d497088323a441f33bda8c16d4