### PR TITLE
chore: add npmrc, scripts, and supabase subscription guard

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=false

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Added `.npmrc` with `shamefully-hoist=false` and expanded npm scripts for development and diagnostics.
 - Pinned Expo, React, React Native, and Metro versions and switched to `pnpm`.
 - Added `clean` script for wiping caches and reinstalling dependencies.
 - Covered invalid JSON and missing type cases in `onMessage` tests.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
+    "dev": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
+    "build": "expo build",
     "web": "expo start --web",
     "test": "node --import tsx node_modules/jest/bin/jest.js",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
+    "doctor": "expo doctor",
     "apk:debug": "npx expo run:android --variant debug",
     "prepare": "husky install",
     "clean": "rimraf node_modules .expo .turbo .cache && rimraf pnpm-lock.yaml"

--- a/src/services/__tests__/supabase.test.ts
+++ b/src/services/__tests__/supabase.test.ts
@@ -1,0 +1,32 @@
+import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+import type { LightCycle } from '../../domain/types';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn(),
+    })),
+  })),
+}));
+
+import { supabaseService, supabase } from '../supabase';
+
+describe('subscribeLightCycles', () => {
+  it('ignores events without new payload', () => {
+    const cb = jest.fn();
+
+    supabaseService.subscribeLightCycles(cb);
+
+    const channel = (supabase.channel as jest.Mock).mock.results[0].value;
+    const handler = channel.on.mock.calls[0][2] as (
+      payload: RealtimePostgresChangesPayload<LightCycle>,
+    ) => void;
+    const payload = {
+      new: null,
+    } as unknown as RealtimePostgresChangesPayload<LightCycle>;
+    handler(payload);
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -67,8 +67,11 @@ function subscribeLightCycles(
     .on(
       'postgres_changes',
       { event: '*', schema: 'public', table: 'light_cycles' },
-      (payload: RealtimePostgresChangesPayload<LightCycle>) =>
-        cb(payload.new as LightCycle),
+      (payload: RealtimePostgresChangesPayload<LightCycle>) => {
+        if (payload.new) {
+          cb(payload.new as LightCycle);
+        }
+      },
     )
     .subscribe();
 }


### PR DESCRIPTION
## Summary
- add .npmrc to disable hoisting
- expose dev/build/doctor scripts in package.json
- guard supabase subscription against missing payload and test
- document new scripts in README

## Testing
- `pnpm lint --fix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b0c9d9649483238199b975084ded48