### PR TITLE
feat: add lights migration and seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Run unit tests:
 npm test -- --coverage
 ```
 
+### Database
+
+Manage Supabase migrations with the CLI:
+
+```
+supabase db reset   # recreate database with latest migrations
+supabase db push    # apply migrations to the remote project
+```
+
 ### Debugging
 
 Write debug messages to `data/app.log` with the logger:

--- a/supabase/AGENTS.md
+++ b/supabase/AGENTS.md
@@ -1,0 +1,11 @@
+# Supabase
+
+SQL migrations live under `migrations/` and seeds under `seed/`.
+Run migrations locally with the Supabase CLI:
+
+```bash
+supabase db reset   # recreate database with latest migrations
+supabase db push    # apply migrations to remote project
+```
+
+Keep SQL formatted and include RLS policies for new tables.

--- a/supabase/migrations/20250101_lights.sql
+++ b/supabase/migrations/20250101_lights.sql
@@ -1,0 +1,39 @@
+-- Create lights table
+create table if not exists public.lights (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  latitude double precision not null,
+  longitude double precision not null,
+  created_at timestamptz not null default now()
+);
+
+-- Create light_phases table
+create table if not exists public.light_phases (
+  id uuid primary key default gen_random_uuid(),
+  light_id uuid not null references public.lights(id) on delete cascade,
+  phase text not null,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz
+);
+
+-- Indices
+create index if not exists light_phases_light_id_idx on public.light_phases(light_id);
+create index if not exists light_phases_started_at_idx on public.light_phases(started_at);
+
+-- RLS
+alter table public.lights enable row level security;
+alter table public.light_phases enable row level security;
+
+-- Anonymous read
+create policy "Anon read lights" on public.lights
+  for select using (true);
+create policy "Anon read light_phases" on public.light_phases
+  for select using (true);
+
+-- Authenticated write
+create policy "Auth write lights" on public.lights
+  for all using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+create policy "Auth write light_phases" on public.light_phases
+  for all using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');

--- a/supabase/seed/lights_seed.sql
+++ b/supabase/seed/lights_seed.sql
@@ -1,0 +1,11 @@
+-- Sample lights
+insert into public.lights (id, name, latitude, longitude) values
+  ('00000000-0000-0000-0000-000000000001', 'Main & 1st', 40.7128, -74.0060),
+  ('00000000-0000-0000-0000-000000000002', '2nd & Pine', 47.6062, -122.3321),
+  ('00000000-0000-0000-0000-000000000003', 'Market & 5th', 37.7749, -122.4194);
+
+-- Sample phases
+insert into public.light_phases (light_id, phase, started_at, ended_at) values
+  ('00000000-0000-0000-0000-000000000001', 'green', now() - interval '20 seconds', now() - interval '10 seconds'),
+  ('00000000-0000-0000-0000-000000000002', 'red', now() - interval '30 seconds', now() - interval '20 seconds'),
+  ('00000000-0000-0000-0000-000000000003', 'yellow', now() - interval '10 seconds', now());


### PR DESCRIPTION
## Summary
- add `lights` and `light_phases` tables with RLS
- seed sample lights and phases
- document Supabase migration commands

## Testing
- `pre-commit run --files supabase/AGENTS.md supabase/migrations/20250101_lights.sql supabase/seed/lights_seed.sql README.md`
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b0cca53ddc8323a55d12cdcc330dc3