### PR TITLE
feat: add light status badge and module loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Added LightStatusBadge component showing upcoming traffic-light phases.
+- Added markup mode toggle for map overlays.
+- Exposed grouped modules in `index.ts` for easier testing.
 - Introduced shared Supabase client (`src/lib/supabase.ts`) and a lights service with CRUD and phase helpers backed by Vitest tests.
 - Added lights migration and seed data for traffic-light management.
 - Added `.npmrc` with `shamefully-hoist=false` and expanded npm scripts for development and diagnostics.

--- a/src/features/lights/AGENTS.md
+++ b/src/features/lights/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS
+
+Guidelines for the lights feature.
+
+- UI components use functional React with `StyleSheet.create`.
+- Keep services and hooks pure.
+- Place tests next to the code they cover.
+- After changes run:
+  ```bash
+  pre-commit run --files <files>
+  npm test -- --coverage
+  ```

--- a/src/features/lights/LightStatusBadge.test.tsx
+++ b/src/features/lights/LightStatusBadge.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('../../services/lights', () => ({
+  getUpcomingPhase: jest.fn(),
+}));
+
+import { LightStatusBadge } from './LightStatusBadge';
+import { getUpcomingPhase } from '../../services/lights';
+
+jest.mock('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  StyleSheet: { create: () => ({}), flatten: (s: unknown) => s },
+}));
+const mocked = getUpcomingPhase as jest.MockedFunction<typeof getUpcomingPhase>;
+
+test('shows countdown and switches to next phase', async () => {
+  mocked
+    .mockResolvedValueOnce({ direction: 'MAIN', startIn: 2 })
+    .mockResolvedValueOnce({ direction: 'SECONDARY', startIn: 3 })
+    .mockResolvedValueOnce({ direction: 'PEDESTRIAN', startIn: 4 });
+
+  jest.useFakeTimers();
+  const { getByText } = render(<LightStatusBadge lightId="1" />);
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(getByText('🟢 2s')).toBeTruthy();
+
+  await act(async () => {
+    jest.advanceTimersByTime(2000);
+  });
+  expect(getByText('🟡 3s')).toBeTruthy();
+  jest.useRealTimers();
+});

--- a/src/features/lights/LightStatusBadge.tsx
+++ b/src/features/lights/LightStatusBadge.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { getUpcomingPhase, UpcomingPhase } from '../../services/lights';
+
+const overlay = '#00000088';
+
+interface Props {
+  lightId: string;
+}
+
+export function LightStatusBadge({ lightId }: Props) {
+  const [phase, setPhase] = useState<UpcomingPhase | null>(null);
+  const nextRef = useRef<UpcomingPhase | null>(null);
+  const [seconds, setSeconds] = useState(0);
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      const current = await getUpcomingPhase(lightId);
+      if (!mounted || !current) return;
+      setPhase(current);
+      const upcoming = await getUpcomingPhase(
+        lightId,
+        new Date(Date.now() + current.startIn * 1000),
+      );
+      if (mounted) nextRef.current = upcoming;
+      setSeconds(Math.ceil(current.startIn));
+    }
+    load();
+    const id = setInterval(() => {
+      setSeconds((s) => {
+        if (s <= 1) {
+          const next = nextRef.current;
+          if (next) {
+            setPhase(next);
+            getUpcomingPhase(
+              lightId,
+              new Date(Date.now() + next.startIn * 1000),
+            ).then((p) => {
+              nextRef.current = p;
+            });
+            return Math.ceil(next.startIn);
+          }
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => {
+      mounted = false;
+      clearInterval(id);
+    };
+  }, [lightId]);
+
+  if (!phase) return null;
+
+  const icon =
+    phase.direction === 'MAIN'
+      ? '🟢'
+      : phase.direction === 'SECONDARY'
+        ? '🟡'
+        : '🚶';
+
+  return (
+    <View style={styles.badge}>
+      <Text>
+        {icon} {seconds}s
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    backgroundColor: overlay,
+    borderRadius: 4,
+    padding: 4,
+  },
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,6 +6,8 @@ import {
   processors,
   sources,
   stores,
+  getCommands,
+  getStores,
 } from './index';
 
 describe('index navigation facade', () => {
@@ -36,5 +38,15 @@ describe('index navigation facade', () => {
     expect(typeof processors).toBe('object');
     expect(typeof sources).toBe('object');
     expect(typeof stores).toBe('object');
+  });
+
+  it('returns fresh copies from getters', () => {
+    const a = getCommands() as Record<string, unknown>;
+    (a as Record<string, unknown>)['foo'] = 1;
+    const b = getCommands() as Record<string, unknown>;
+    expect(b['foo']).toBeUndefined();
+    const s1 = getStores();
+    const s2 = getStores();
+    expect(s1).not.toBe(s2);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,28 @@ import * as storeModules from './stores';
 
 export { cloneNavigationState } from './features/navigation/cloneNavigationState';
 export { createNavigation, initialState } from './navigationFactory';
-export const commands = commandModules;
-export const processors = processorModules;
-export const sources = sourceModules;
-export const stores = storeModules;
+
+export function getCommands() {
+  return { ...commandModules };
+}
+
+export function getProcessors() {
+  return { ...processorModules };
+}
+
+export function getSources() {
+  return { ...sourceModules };
+}
+
+export function getStores() {
+  return { ...storeModules };
+}
+
+export const commands = getCommands();
+export const processors = getProcessors();
+export const sources = getSources();
+export const stores = getStores();
+
 export * from './commands';
 export * from './processors';
 export * from './sources';


### PR DESCRIPTION
## Summary
- display traffic-light phase countdown with LightStatusBadge
- expose module loader helpers in index.ts
- document recent changes

## Testing
- `npm run lint`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b0d4b53d4c8323a3929b6ccb7bdaed