### PR TITLE
feat: add speed advisor component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Added destination selection to navigation helpers.
+- Included `.env.example` with required keys.
+- Introduced SpeedAdvisor component to compute safe speed ranges for green windows.
+
 - Added LightStatusBadge component showing upcoming traffic-light phases.
 - Added markup mode toggle for map overlays.
 - Exposed grouped modules in `index.ts` for easier testing.

--- a/src/features/advice/AGENTS.md
+++ b/src/features/advice/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS
+
+Components providing driving advice belong here.
+- Use React functional components with hooks.
+- Include tests next to the components.
+- Run `pre-commit run --files <files>` and `npm test -- --coverage` after changes.

--- a/src/features/advice/SpeedAdvisor.test.tsx
+++ b/src/features/advice/SpeedAdvisor.test.tsx
@@ -1,0 +1,18 @@
+import { calcSpeedRange } from './SpeedAdvisor';
+
+describe('calcSpeedRange', () => {
+  it('returns clamped range within 10-60 km/h', () => {
+    const res = calcSpeedRange(1000, 200, 1000);
+    expect(res).toEqual({ min: 10, max: 18 });
+  });
+
+  it('clamps speeds above 60', () => {
+    const res = calcSpeedRange(100, 1, 2);
+    expect(res).toEqual({ min: 60, max: 60 });
+  });
+
+  it('returns null for invalid window', () => {
+    expect(calcSpeedRange(1000, -1, 5)).toBeNull();
+    expect(calcSpeedRange(1000, 5, 5)).toBeNull();
+  });
+});

--- a/src/features/advice/SpeedAdvisor.tsx
+++ b/src/features/advice/SpeedAdvisor.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+export interface SpeedRange {
+  min: number;
+  max: number;
+}
+
+// calculate speed range in km/h to cover distance within window
+export function calcSpeedRange(
+  dist_m: number,
+  start_s: number,
+  end_s: number,
+): SpeedRange | null {
+  if (start_s <= 0 || end_s <= 0 || start_s >= end_s) return null;
+  const min = (dist_m / end_s) * 3.6;
+  const max = (dist_m / start_s) * 3.6;
+  const clampedMin = Math.max(10, Math.min(60, min));
+  const clampedMax = Math.max(10, Math.min(60, max));
+  if (clampedMin > clampedMax) return null;
+  return { min: clampedMin, max: clampedMax };
+}
+
+interface Props {
+  dist_m: number;
+  start_s: number;
+  end_s: number;
+}
+
+// Displays speed range or fallback text
+export function SpeedAdvisor({ dist_m, start_s, end_s }: Props) {
+  const range = calcSpeedRange(dist_m, start_s, end_s);
+  if (!range) return <Text>No green window</Text>;
+  const { min, max } = range;
+  return <Text>{`${min.toFixed(0)}–${max.toFixed(0)} km/h`}</Text>;
+}


### PR DESCRIPTION
## Summary
- compute clamped speed range for upcoming green window
- document latest changes and add advice feature guide

## Testing
- `pre-commit run --files src/features/advice/AGENTS.md src/features/advice/SpeedAdvisor.tsx src/features/advice/SpeedAdvisor.test.tsx README.md`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test -- --coverage` *(fails: Cannot find package 'tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68b0db49e37c8323b5fceafe6ce6e877