### PR TITLE
refactor: make module getters overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 
 ## Recent changes
 
+- Implemented speed range calculation for green-window recommendations in `SpeedAdvisor`.
 - Added destination selection to navigation helpers.
 - Included `.env.example` with required keys.
 - Introduced SpeedAdvisor component to compute safe speed ranges for green windows.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -42,11 +42,17 @@ describe('index navigation facade', () => {
 
   it('returns fresh copies from getters', () => {
     const a = getCommands() as Record<string, unknown>;
-    (a as Record<string, unknown>)['foo'] = 1;
+    (a as any).foo = 1;
     const b = getCommands() as Record<string, unknown>;
-    expect(b['foo']).toBeUndefined();
+    expect((b as any).foo).toBeUndefined();
     const s1 = getStores();
     const s2 = getStores();
     expect(s1).not.toBe(s2);
+  });
+
+  it('merges overrides without mutating defaults', () => {
+    const custom = getCommands({ test: () => true } as any);
+    expect(typeof (custom as any).test).toBe('function');
+    expect((commands as any).test).toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,21 +6,16 @@ import * as storeModules from './stores';
 export { cloneNavigationState } from './features/navigation/cloneNavigationState';
 export { createNavigation, initialState } from './navigationFactory';
 
-export function getCommands() {
-  return { ...commandModules };
+type ModuleMap = Record<string, unknown>;
+
+function createGetter<T extends ModuleMap>(defaults: T) {
+  return (overrides: Partial<T> = {}): T => ({ ...defaults, ...overrides });
 }
 
-export function getProcessors() {
-  return { ...processorModules };
-}
-
-export function getSources() {
-  return { ...sourceModules };
-}
-
-export function getStores() {
-  return { ...storeModules };
-}
+export const getCommands = createGetter(commandModules);
+export const getProcessors = createGetter(processorModules);
+export const getSources = createGetter(sourceModules);
+export const getStores = createGetter(storeModules);
 
 export const commands = getCommands();
 export const processors = getProcessors();


### PR DESCRIPTION
## Summary
- allow overriding module registries in `index.ts`
- document speed range calculation in README
- test `getCommands` override behavior

## Testing
- `pre-commit run --files README.md src/index.ts src/index.test.ts`
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test -- --coverage` *(fails: Cannot find package 'tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68b115439cc883239ff94aab06f636d9