### PR TITLE
docs: add PR guide and template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+Describe your changes.
+
+## Testing
+
+- [ ] `pre-commit run --files <files>`
+- [ ] `pnpm lint --format unix`
+- [ ] `pnpm test --coverage`
+
+## Notes
+
+Optional extra context.
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ React Native (Expo) app with real-time traffic-light detection, premium subscrip
 - `feature/*` – feature development branches.
 - `hotfix/*` – urgent fixes based off `main`.
 
+## Creating a Pull Request
+
+```bash
+git checkout -b feature/<name>
+pre-commit run --files <files>
+pnpm lint --format unix
+pnpm test --coverage
+git commit -am "feat: add amazing thing"
+git push origin feature/<name>
+```
+
+Open a pull request on GitHub and request a review.
+
+### Branch protection
+
+- Direct pushes to `main` are blocked.
+- Merging into `main` requires at least one approved review.
+
 ## Recent changes
 
 - Added design tokens (`src/styles/tokens.ts`) and a reusable `Card` UI component.


### PR DESCRIPTION
## Summary
- document PR workflow and branch protection in README
- add pull request template

## Testing
- `pre-commit run --files README.md .github/PULL_REQUEST_TEMPLATE.md`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b12bb49a388323b306ace763789fb2