### PR TITLE
ci: run npm tests with coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           cache: 'pnpm'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test --coverage
+      - run: npm test -- --coverage
       - run: pnpm test:vitest
       - uses: codecov/codecov-action@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Tests live beside the code they verify, and coverage reports are stored under `c
 - `pnpm install` – install dependencies.
 - `pnpm run clean` – reset caches and lockfile.
 - `npx expo start` – launch the development server.
-- `pnpm test --coverage` – run the Jest suite with coverage.
+- `npm test -- --coverage` – run the Jest suite with coverage.
 - `pnpm lint` – check JavaScript and TypeScript code style.
 - Node scripts use the [`tsx`](https://github.com/privatenumber/tsx) loader via `node --loader tsx`.
 
@@ -60,7 +60,7 @@ Run these commands before committing:
 ```bash
 pre-commit run --files <files>
 pnpm lint --format unix
-pnpm test --coverage
+npm test -- --coverage
 ```
 
 Tests should pass and formatting hooks should run on the changed files. The `test` workflow uploads `coverage/lcov.info` to Codecov.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [docs/API.md](docs/API.md) for available REST endpoints.
 git checkout -b feature/<name>
 pre-commit run --files <files>
 pnpm lint --format unix
-pnpm test --coverage
+npm test -- --coverage
 git commit -am "feat: add amazing thing"
 git push origin feature/<name>
 ```
@@ -34,6 +34,9 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Added API reference documentation and `.env.example` template.
+- Added pull request guide and template for contributors.
+- Added quality workflow to CI.
 - Added design tokens (`src/styles/tokens.ts`) and a reusable `Card` UI component.
 - Introduced light/dark theme switcher with persisted preference.
 - Integrated combobox-based search in the toolbar.
@@ -55,7 +58,7 @@ Open a pull request on GitHub and request a review.
 - Added `clean` script for wiping caches and reinstalling dependencies.
 - Covered invalid JSON and missing type cases in `onMessage` tests.
 - Unified test command across documentation.
- - Dropped coverage npm script; run tests with `pnpm test --coverage`.
+- Dropped coverage npm script; run tests with `npm test -- --coverage`.
 - Re-exported `cloneNavigationState` from the navigation feature and removed duplicate implementation.
 - Renamed project heading to "greenWave".
 - Added tests to ensure navigation maneuvers remain isolated between runs.
@@ -140,7 +143,7 @@ npx expo start -c
 Run unit tests:
 
 ```
-pnpm test --coverage
+npm test -- --coverage
 ```
 
 ### Database

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
-import { initRegistry } from './index';
+import { initRegistry, getRegistry } from './index';
 
-describe('createRegistry', () => {
+describe('registry', () => {
   it('merges overrides into default modules', () => {
     const customCommand = () => {};
     const reg = initRegistry({ commands: { customCommand } });
@@ -9,5 +9,14 @@ describe('createRegistry', () => {
     expect(reg.processors).toBeDefined();
     expect(reg.sources).toBeDefined();
     expect(reg.stores).toBeDefined();
+  });
+
+  it('returns the same instance unless reinitialized', () => {
+    const first = getRegistry();
+    const second = getRegistry();
+    expect(first).toBe(second);
+    const otherCommand = () => {};
+    initRegistry({ commands: { otherCommand } });
+    expect(getRegistry().commands.otherCommand).toBe(otherCommand);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,34 @@ export { cloneNavigationState } from './features/navigation/cloneNavigationState
 export { createNavigation, initialState } from './navigationFactory';
 export { createRegistry } from './registry';
 
+let registry: ReturnType<typeof createRegistry> | null = null;
+
 export function initRegistry(
   overrides?: Parameters<typeof createRegistry>[0],
 ): ReturnType<typeof createRegistry> {
-  return createRegistry(overrides);
+  registry = createRegistry(overrides);
+  return registry;
 }
 
-export const { commands, processors, sources, stores } = initRegistry();
+export function getRegistry(): ReturnType<typeof createRegistry> {
+  return registry ?? initRegistry();
+}
+
+export function getCommands() {
+  return getRegistry().commands;
+}
+
+export function getProcessors() {
+  return getRegistry().processors;
+}
+
+export function getSources() {
+  return getRegistry().sources;
+}
+
+export function getStores() {
+  return getRegistry().stores;
+}
 
 export * from './commands';
 export * from './processors';

--- a/src/services/__tests__/lights.test.ts
+++ b/src/services/__tests__/lights.test.ts
@@ -6,14 +6,14 @@ const singleLight = vi.fn();
 interface LightInsert {
   select: () => { single: typeof singleLight };
 }
-const insert = vi.fn<(arg: unknown) => LightInsert>();
+const insert = vi.fn<[unknown], LightInsert>();
 
 const singleCycle = vi.fn();
 interface CycleSelect {
   eq: () => { order: () => { limit: () => { single: typeof singleCycle } } };
 }
 const upsert = vi.fn();
-const selectCycle = vi.fn<() => CycleSelect>();
+const selectCycle = vi.fn<[], CycleSelect>();
 
 vi.mock('../../lib/supabase', () => ({
   supabase: {


### PR DESCRIPTION
## Summary
- test workflow uses `npm test -- --coverage` and uploads to Codecov
- document npm test command and latest changes in README/AGENTS
- refactor registry helpers and expand tests
- fix Vitest mocks in lights service tests

## Testing
- `pre-commit run --files AGENTS.md README.md .github/workflows/test.yml src/index.ts src/index.test.ts src/services/__tests__/lights.test.ts`
- `pnpm lint --format unix`
- `npm test -- --coverage`
- `pnpm test:vitest` *(fails: Expected 'from', got 'typeOf'; ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b1333100448323acbe8b91641d8e1f