### PR TITLE
docs: document coverage workflow and tighten logger test

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- CI now runs tests with coverage and uploads reports to Codecov.
 - Added API reference documentation and `.env.example` template.
 - Added pull request guide and template for contributors.
 - Added quality workflow to CI.

--- a/src/services/__tests__/logger.test.ts
+++ b/src/services/__tests__/logger.test.ts
@@ -9,11 +9,14 @@ describe('logger', () => {
   });
 
   it('writes formatted log line', async () => {
-    await log('INFO', 'test message');
+    const level = 'INFO';
+    const message = 'test message';
+    await log(level, message);
     const content = fs.readFileSync(file, 'utf8').trim();
     const line = content.split('\n').pop();
-    expect(line).toMatch(
-      /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \[INFO\] test message/,
+    const pattern = new RegExp(
+      `^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\[${level}\\] ${message}$`,
     );
+    expect(line).toMatch(pattern);
   });
 });


### PR DESCRIPTION
## Summary
- document that CI uploads coverage to Codecov
- verify logger writes lines in `YYYY-MM-DD HH:MM:SS [LEVEL] message` format

## Testing
- `pre-commit run --files README.md src/services/__tests__/logger.test.ts`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b1377ac29483238503be2c09939419