### PR TITLE
feat: add typed onMessage handler map

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Routed `onMessage` handling through a type-specific handler map.
 - Split `onMessage` into parsing, validation, and handling modules.
 - Moved validation helpers to `src/utils` for reuse.
 - Made module registry injectable for easier overriding in tests.

--- a/src/services/__tests__/onMessage.test.ts
+++ b/src/services/__tests__/onMessage.test.ts
@@ -2,6 +2,7 @@ import {
   parseMessage,
   validateMessage,
   handleMessage,
+  handlers,
   onMessage,
 } from '../onMessage';
 import { log } from '../logger';
@@ -9,6 +10,10 @@ import { log } from '../logger';
 jest.mock('../logger', () => ({
   log: jest.fn().mockResolvedValue(undefined),
 }));
+
+beforeEach(() => {
+  (log as jest.Mock).mockClear();
+});
 
 describe('parseMessage', () => {
   it('parses JSON string', () => {
@@ -34,17 +39,25 @@ describe('validateMessage', () => {
 });
 
 describe('handleMessage', () => {
-  it('logs received type', async () => {
+  it('dispatches to handler', async () => {
     await handleMessage({ type: 'ping' });
+    expect(log).toHaveBeenCalledWith('INFO', 'received ping');
+  });
+
+  it('ignores unknown types', async () => {
+    await handleMessage({ type: 'other' });
+    expect(log).not.toHaveBeenCalled();
+  });
+});
+
+describe('handlers', () => {
+  it('ping handler logs message', async () => {
+    await handlers.ping({ type: 'ping' });
     expect(log).toHaveBeenCalledWith('INFO', 'received ping');
   });
 });
 
 describe('onMessage', () => {
-  beforeEach(() => {
-    (log as jest.Mock).mockClear();
-  });
-
   it('runs full pipeline', async () => {
     await onMessage('{"type":"ping"}');
     expect(log).toHaveBeenCalledWith('INFO', 'received ping');

--- a/src/services/onMessage/handle.ts
+++ b/src/services/onMessage/handle.ts
@@ -1,6 +1,9 @@
-import { log } from '../logger';
 import type { Message } from './types';
+import { handlers } from './handlers';
 
 export async function handleMessage(message: Message): Promise<void> {
-  await log('INFO', `received ${message.type}`);
+  const handler = handlers[message.type];
+  if (handler) {
+    await handler(message);
+  }
 }

--- a/src/services/onMessage/handlers.ts
+++ b/src/services/onMessage/handlers.ts
@@ -1,0 +1,10 @@
+import { log } from '../logger';
+import type { HandlerMap } from './types';
+
+export const handlers: HandlerMap = {
+  ping: async () => {
+    await log('INFO', 'received ping');
+  },
+};
+
+export default handlers;

--- a/src/services/onMessage/index.ts
+++ b/src/services/onMessage/index.ts
@@ -1,7 +1,8 @@
 import { parseMessage } from './parse';
 import { validateMessage } from './validate';
 import { handleMessage } from './handle';
-export type { Message } from './types';
+export type { Message, MessageHandler, HandlerMap } from './types';
+export { handlers } from './handlers';
 
 export { parseMessage, validateMessage, handleMessage };
 

--- a/src/services/onMessage/types.ts
+++ b/src/services/onMessage/types.ts
@@ -2,3 +2,7 @@ export interface Message {
   type: string;
   payload?: unknown;
 }
+
+export type MessageHandler = (message: Message) => void | Promise<void>;
+
+export type HandlerMap = Record<string, MessageHandler>;


### PR DESCRIPTION
## Summary
- add HandlerMap and MessageHandler types for onMessage service
- dispatch messages via type-specific handlers
- test handler dispatch and export helpers

## Testing
- `pre-commit run --files README.md src/services/__tests__/onMessage.test.ts src/services/onMessage/handle.ts src/services/onMessage/index.ts src/services/onMessage/types.ts src/services/onMessage/handlers.ts`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b14162e18c8323afee52a1f77ca090