### PR TITLE
feat: add modular gpt service

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Added modular GPT service with API client, prompt formatter, and utilities.
 - Routed `onMessage` handling through a type-specific handler map.
 - Split `onMessage` into parsing, validation, and handling modules.
 - Moved validation helpers to `src/utils` for reuse.

--- a/src/services/gpt/AGENTS.md
+++ b/src/services/gpt/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+Guidelines for GPT service modules.
+
+- Keep API calls isolated in `apiClient.ts` with injectable `fetch` for testing.
+- Pure helpers belong in `utils.ts` and should remain stateless.
+- `promptHandler.ts` formats prompts without side effects.
+- Place tests in `__tests__/` alongside the modules.
+- Run `pre-commit run --files <files>` and `npm test -- --coverage` after changes.

--- a/src/services/gpt/__tests__/apiClient.test.ts
+++ b/src/services/gpt/__tests__/apiClient.test.ts
@@ -1,0 +1,18 @@
+import { createGptClient } from '../apiClient';
+
+describe('createGptClient', () => {
+  it('calls fetch with correct payload and returns text', async () => {
+    const mockFetch = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue({
+        json: async () => ({ choices: [{ message: { content: 'ok' } }] }),
+      } as unknown as Response);
+    const client = createGptClient('k', mockFetch);
+    const text = await client.complete('hi');
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(text).toBe('ok');
+  });
+});

--- a/src/services/gpt/__tests__/promptHandler.test.ts
+++ b/src/services/gpt/__tests__/promptHandler.test.ts
@@ -1,0 +1,8 @@
+import { buildPrompt } from '../promptHandler';
+
+describe('buildPrompt', () => {
+  it('replaces variables in template', () => {
+    const result = buildPrompt('Hello {name}', { name: 'Alice' });
+    expect(result).toBe('Hello Alice');
+  });
+});

--- a/src/services/gpt/__tests__/utils.test.ts
+++ b/src/services/gpt/__tests__/utils.test.ts
@@ -1,0 +1,8 @@
+import { trimLines } from '../utils';
+
+describe('trimLines', () => {
+  it('trims whitespace per line', () => {
+    const text = '  a  \n  b  ';
+    expect(trimLines(text)).toBe('a\nb');
+  });
+});

--- a/src/services/gpt/apiClient.ts
+++ b/src/services/gpt/apiClient.ts
@@ -1,0 +1,31 @@
+export interface GptClient {
+  complete(prompt: string): Promise<string>;
+}
+
+export function createGptClient(
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): GptClient {
+  return {
+    async complete(prompt: string): Promise<string> {
+      const res = await fetchImpl(
+        'https://api.openai.com/v1/chat/completions',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-3.5-turbo',
+            messages: [{ role: 'user', content: prompt }],
+          }),
+        },
+      );
+      const data = (await res.json()) as {
+        choices: { message: { content: string } }[];
+      };
+      return data.choices[0]?.message.content ?? '';
+    },
+  };
+}

--- a/src/services/gpt/index.ts
+++ b/src/services/gpt/index.ts
@@ -1,0 +1,3 @@
+export * from './apiClient';
+export * from './promptHandler';
+export * from './utils';

--- a/src/services/gpt/promptHandler.ts
+++ b/src/services/gpt/promptHandler.ts
@@ -1,0 +1,6 @@
+export function buildPrompt(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) => vars[key] ?? '');
+}

--- a/src/services/gpt/utils.ts
+++ b/src/services/gpt/utils.ts
@@ -1,0 +1,7 @@
+export function trimLines(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    .trim();
+}


### PR DESCRIPTION
## Summary
- split GPT client into api client, prompt builder, and helpers
- add tests for each GPT module
- document GPT service in README

## Testing
- `pre-commit run --files README.md src/services/gpt/AGENTS.md src/services/gpt/apiClient.ts src/services/gpt/promptHandler.ts src/services/gpt/utils.ts src/services/gpt/index.ts src/services/gpt/__tests__/apiClient.test.ts src/services/gpt/__tests__/promptHandler.test.ts src/services/gpt/__tests__/utils.test.ts`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b1438a3b148323a247100efc36350e