### PR TITLE
refactor: add registry manager for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025-08
 
+- refactor: extract registry manager factory for isolated tests
 - refactor: convert remaining `.js` files to `.ts`/`.tsx` and add `tsx` loader
 - chore: refine navigation initialization for improved testability
 - feat: scaffold command and data layers

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.
 - Routed `onMessage` handling through a type-specific handler map.
 - Split `onMessage` into parsing, validation, and handling modules.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   setRegistry,
   resetRegistry,
   getCommands,
+  createRegistryManager,
 } from './index';
 import { createRegistry } from './registry';
 
@@ -47,5 +48,15 @@ describe('registry', () => {
   it('getCommands uses provided registry', () => {
     const custom = createRegistry({ commands: { foo: () => {} } });
     expect(getCommands(custom).foo).toBeDefined();
+  });
+});
+
+describe('createRegistryManager', () => {
+  it('creates isolated registries', () => {
+    const mgr1 = createRegistryManager();
+    const mgr2 = createRegistryManager();
+    mgr1.initRegistry({ commands: { foo: () => {} } });
+    expect(mgr1.getCommands().foo).toBeDefined();
+    expect(mgr2.getCommands().foo).toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,45 +4,69 @@ export { cloneNavigationState } from './features/navigation/cloneNavigationState
 export { createNavigation, initialState } from './navigationFactory';
 export { createRegistry } from './registry';
 
-let registry: ReturnType<typeof createRegistry> | null = null;
+export function createRegistryManager(
+  factory: typeof createRegistry = createRegistry,
+) {
+  let registry: ReturnType<typeof factory> | null = null;
 
-export function setRegistry(
-  reg: ReturnType<typeof createRegistry> | null,
-): void {
-  registry = reg;
+  function setRegistry(reg: ReturnType<typeof factory> | null): void {
+    registry = reg;
+  }
+
+  function initRegistry(
+    overrides?: Parameters<typeof factory>[0],
+  ): ReturnType<typeof factory> {
+    const reg = factory(overrides);
+    setRegistry(reg);
+    return reg;
+  }
+
+  function getRegistry(): ReturnType<typeof factory> {
+    return registry ?? initRegistry();
+  }
+
+  function resetRegistry(): void {
+    setRegistry(null);
+  }
+
+  function getCommands(reg = getRegistry()) {
+    return reg.commands;
+  }
+
+  function getProcessors(reg = getRegistry()) {
+    return reg.processors;
+  }
+
+  function getSources(reg = getRegistry()) {
+    return reg.sources;
+  }
+
+  function getStores(reg = getRegistry()) {
+    return reg.stores;
+  }
+
+  return {
+    setRegistry,
+    initRegistry,
+    getRegistry,
+    resetRegistry,
+    getCommands,
+    getProcessors,
+    getSources,
+    getStores,
+  };
 }
 
-export function initRegistry(
-  overrides?: Parameters<typeof createRegistry>[0],
-): ReturnType<typeof createRegistry> {
-  const reg = createRegistry(overrides);
-  setRegistry(reg);
-  return reg;
-}
-
-export function getRegistry(): ReturnType<typeof createRegistry> {
-  return registry ?? initRegistry();
-}
-
-export function resetRegistry(): void {
-  setRegistry(null);
-}
-
-export function getCommands(reg = getRegistry()) {
-  return reg.commands;
-}
-
-export function getProcessors(reg = getRegistry()) {
-  return reg.processors;
-}
-
-export function getSources(reg = getRegistry()) {
-  return reg.sources;
-}
-
-export function getStores(reg = getRegistry()) {
-  return reg.stores;
-}
+export const {
+  setRegistry,
+  initRegistry,
+  getRegistry,
+  resetRegistry,
+  getCommands,
+  getProcessors,
+  getSources,
+  getStores,
+} = createRegistryManager();
 
 export * from './commands';
 export * from './processors';


### PR DESCRIPTION
## Summary
- extract registry manager factory for isolated testing
- cover registry manager behavior with new tests
- document registry manager in changelog and readme

## Testing
- `pre-commit run --files README.md CHANGELOG.md src/index.ts src/index.test.ts`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b145e57828832380e1d49befdb2545