### PR TITLE
fix: handle gpt api errors

### DIFF
--- a/src/services/gpt/__tests__/apiClient.test.ts
+++ b/src/services/gpt/__tests__/apiClient.test.ts
@@ -1,10 +1,12 @@
 import { createGptClient } from '../apiClient';
+import * as logger from '../../logger';
 
 describe('createGptClient', () => {
   it('calls fetch with correct payload and returns text', async () => {
     const mockFetch = jest
       .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
       .mockResolvedValue({
+        ok: true,
         json: async () => ({ choices: [{ message: { content: 'ok' } }] }),
       } as unknown as Response);
     const client = createGptClient('k', mockFetch);
@@ -14,5 +16,35 @@ describe('createGptClient', () => {
       expect.objectContaining({ method: 'POST' }),
     );
     expect(text).toBe('ok');
+  });
+
+  it('throws error text when response not ok', async () => {
+    const mockFetch = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue({
+        ok: false,
+        text: async () => 'bad',
+      } as unknown as Response);
+    const client = createGptClient('k', mockFetch);
+    await expect(client.complete('hi')).rejects.toThrow('bad');
+  });
+
+  it('logs and rethrows on json parse error', async () => {
+    const mockFetch = jest
+      .fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>()
+      .mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error('nojson');
+        },
+      } as unknown as Response);
+    const logSpy = jest.spyOn(logger, 'log').mockResolvedValue(undefined);
+    const client = createGptClient('k', mockFetch);
+    await expect(client.complete('hi')).rejects.toThrow('nojson');
+    expect(logSpy).toHaveBeenCalledWith(
+      'ERROR',
+      expect.stringContaining('nojson'),
+    );
+    logSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- handle non-OK responses in GPT API client
- log JSON parse failures and rethrow errors
- test GPT client error paths

## Testing
- `pre-commit run --files src/services/gpt/apiClient.ts src/services/gpt/__tests__/apiClient.test.ts`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b14c111c648323b2bf6693afcc1508