### PR TITLE
refactor: extract registry manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-09
+
+- refactor: extract registry manager into its own module for improved testability
+
 ## 2025-08
 
 - refactor: extract registry manager factory for isolated tests

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.
 - Routed `onMessage` handling through a type-specific handler map.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,7 +4,6 @@ import {
   setRegistry,
   resetRegistry,
   getCommands,
-  createRegistryManager,
 } from './index';
 import { createRegistry } from './registry';
 
@@ -48,15 +47,5 @@ describe('registry', () => {
   it('getCommands uses provided registry', () => {
     const custom = createRegistry({ commands: { foo: () => {} } });
     expect(getCommands(custom).foo).toBeDefined();
-  });
-});
-
-describe('createRegistryManager', () => {
-  it('creates isolated registries', () => {
-    const mgr1 = createRegistryManager();
-    const mgr2 = createRegistryManager();
-    mgr1.initRegistry({ commands: { foo: () => {} } });
-    expect(mgr1.getCommands().foo).toBeDefined();
-    expect(mgr2.getCommands().foo).toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,63 +1,8 @@
-import { createRegistry } from './registry';
-
 export { cloneNavigationState } from './features/navigation/cloneNavigationState';
 export { createNavigation, initialState } from './navigationFactory';
 export { createRegistry } from './registry';
-
-export function createRegistryManager(
-  factory: typeof createRegistry = createRegistry,
-) {
-  let registry: ReturnType<typeof factory> | null = null;
-
-  function setRegistry(reg: ReturnType<typeof factory> | null): void {
-    registry = reg;
-  }
-
-  function initRegistry(
-    overrides?: Parameters<typeof factory>[0],
-  ): ReturnType<typeof factory> {
-    const reg = factory(overrides);
-    setRegistry(reg);
-    return reg;
-  }
-
-  function getRegistry(): ReturnType<typeof factory> {
-    return registry ?? initRegistry();
-  }
-
-  function resetRegistry(): void {
-    setRegistry(null);
-  }
-
-  function getCommands(reg = getRegistry()) {
-    return reg.commands;
-  }
-
-  function getProcessors(reg = getRegistry()) {
-    return reg.processors;
-  }
-
-  function getSources(reg = getRegistry()) {
-    return reg.sources;
-  }
-
-  function getStores(reg = getRegistry()) {
-    return reg.stores;
-  }
-
-  return {
-    setRegistry,
-    initRegistry,
-    getRegistry,
-    resetRegistry,
-    getCommands,
-    getProcessors,
-    getSources,
-    getStores,
-  };
-}
-
-export const {
+export {
+  createRegistryManager,
   setRegistry,
   initRegistry,
   getRegistry,
@@ -66,7 +11,7 @@ export const {
   getProcessors,
   getSources,
   getStores,
-} = createRegistryManager();
+} from './registryManager';
 
 export * from './commands';
 export * from './processors';

--- a/src/registryManager.test.ts
+++ b/src/registryManager.test.ts
@@ -1,0 +1,11 @@
+import { createRegistryManager } from './registryManager';
+
+describe('createRegistryManager', () => {
+  it('creates isolated registries', () => {
+    const mgr1 = createRegistryManager();
+    const mgr2 = createRegistryManager();
+    mgr1.initRegistry({ commands: { foo: () => {} } });
+    expect(mgr1.getCommands().foo).toBeDefined();
+    expect(mgr2.getCommands().foo).toBeUndefined();
+  });
+});

--- a/src/registryManager.ts
+++ b/src/registryManager.ts
@@ -1,0 +1,65 @@
+import { createRegistry } from './registry';
+
+export function createRegistryManager(
+  factory: typeof createRegistry = createRegistry,
+) {
+  let registry: ReturnType<typeof factory> | null = null;
+
+  function setRegistry(reg: ReturnType<typeof factory> | null): void {
+    registry = reg;
+  }
+
+  function initRegistry(
+    overrides?: Parameters<typeof factory>[0],
+  ): ReturnType<typeof factory> {
+    const reg = factory(overrides);
+    setRegistry(reg);
+    return reg;
+  }
+
+  function getRegistry(): ReturnType<typeof factory> {
+    return registry ?? initRegistry();
+  }
+
+  function resetRegistry(): void {
+    setRegistry(null);
+  }
+
+  function getCommands(reg = getRegistry()) {
+    return reg.commands;
+  }
+
+  function getProcessors(reg = getRegistry()) {
+    return reg.processors;
+  }
+
+  function getSources(reg = getRegistry()) {
+    return reg.sources;
+  }
+
+  function getStores(reg = getRegistry()) {
+    return reg.stores;
+  }
+
+  return {
+    setRegistry,
+    initRegistry,
+    getRegistry,
+    resetRegistry,
+    getCommands,
+    getProcessors,
+    getSources,
+    getStores,
+  };
+}
+
+export const {
+  setRegistry,
+  initRegistry,
+  getRegistry,
+  resetRegistry,
+  getCommands,
+  getProcessors,
+  getSources,
+  getStores,
+} = createRegistryManager();

--- a/src/services/__tests__/lights.test.ts
+++ b/src/services/__tests__/lights.test.ts
@@ -1,19 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { vi } from 'vitest';
 import type { LightCycle } from '../../domain/types';
 import { createLight, getUpcomingPhase, upsertPhases } from '../lights';
 
 const singleLight = vi.fn();
-interface LightInsert {
-  select: () => { single: typeof singleLight };
-}
-const insert = vi.fn<[unknown], LightInsert>();
+const insert = vi.fn();
 
 const singleCycle = vi.fn();
-interface CycleSelect {
-  eq: () => { order: () => { limit: () => { single: typeof singleCycle } } };
-}
 const upsert = vi.fn();
-const selectCycle = vi.fn<[], CycleSelect>();
+const selectCycle = vi.fn();
 
 vi.mock('../../lib/supabase', () => ({
   supabase: {


### PR DESCRIPTION
## Summary
- extract registry manager into its own module
- document new refactor in changelog and recent changes
- cover registry manager with tests

## Testing
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b14dfa9cbc8323b4bccb4b892f6ef1