### PR TITLE
feat: notify upcoming green phases

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ import {
 import i18n from './src/i18n';
 import { projectLightsToRoute } from './src/domain/matching';
 import { analytics } from './src/services/analytics';
+import { notifyGreenPhase } from './src/services/notifications';
 import {
   handleStartNavigation as startNavigation,
   handleClearRoute as clearRoute,
@@ -131,6 +132,15 @@ export default function App(): JSX.Element {
     const t = setInterval(() => setNowSec(Math.floor(Date.now() / 1000)), 1000);
     return () => clearInterval(t);
   }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      lights.forEach((l) => {
+        void notifyGreenPhase(l.id);
+      });
+    }, 30000);
+    return () => clearInterval(id);
+  }, [lights]);
 
   const onUserLocationChange = (e: UserLocationChangeEvent) => {
     const { coordinate } = e.nativeEvent;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-10
+
+- feat: schedule notifications for upcoming green phases
+
 ## 2025-09
 
 - refactor: extract registry manager into its own module for improved testability

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Added green-phase notifications with periodic checks at startup.
 - Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.

--- a/src/interfaces/notifications.ts
+++ b/src/interfaces/notifications.ts
@@ -7,4 +7,5 @@ export interface PhaseEmitter {
 export interface NotificationsService {
   subscribeToPhaseChanges(emitter: PhaseEmitter): void;
   notifyDriver(phase: PhaseColor): Promise<void>;
+  notifyGreenPhase(lightId: string): Promise<void>;
 }

--- a/src/services/__tests__/lights.test.ts
+++ b/src/services/__tests__/lights.test.ts
@@ -87,4 +87,20 @@ describe('lights service', () => {
     const phase = await getUpcomingPhase('1', new Date(cycle.t0_iso));
     expect(phase?.direction).toBe('MAIN');
   });
+
+  it('returns current phase when already green', async () => {
+    const now = new Date();
+    const cycle: LightCycle = {
+      id: 'c1',
+      light_id: '1',
+      cycle_seconds: 60,
+      t0_iso: new Date(now.getTime() - 5 * 1000).toISOString(),
+      main_green: [0, 10],
+      secondary_green: [20, 30],
+      ped_green: [40, 50],
+    };
+    singleCycle.mockResolvedValueOnce({ data: cycle, error: null });
+    const phase = await getUpcomingPhase('1', now);
+    expect(phase).toEqual({ direction: 'MAIN', startIn: 0 });
+  });
 });

--- a/src/services/lights.ts
+++ b/src/services/lights.ts
@@ -104,6 +104,15 @@ function computeUpcomingPhase(cycle: LightCycle, at: Date): UpcomingPhase {
     { direction: 'SECONDARY', range: cycle.secondary_green },
     { direction: 'PEDESTRIAN', range: cycle.ped_green },
   ];
+
+  for (const { direction, range } of phases) {
+    const [start, end] = range;
+    const inGreen = elapsed >= start && elapsed < end;
+    if (inGreen) {
+      return { direction, startIn: 0 };
+    }
+  }
+
   let best: UpcomingPhase | null = null;
   for (const { direction, range } of phases) {
     const [start] = range;

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -4,6 +4,7 @@ import type {
   PhaseColor,
   PhaseEmitter,
 } from '../interfaces/notifications';
+import { getUpcomingPhase } from './lights';
 
 export async function notifyDriver(phase: PhaseColor): Promise<void> {
   await Notifications.scheduleNotificationAsync({
@@ -21,7 +22,21 @@ export function subscribeToPhaseChanges(emitter: PhaseEmitter): void {
   });
 }
 
+export async function notifyGreenPhase(lightId: string): Promise<void> {
+  const upcoming = await getUpcomingPhase(lightId);
+  if (!upcoming) return;
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Upcoming green',
+      body: `${upcoming.direction} in ${Math.round(upcoming.startIn)}s`,
+    },
+    trigger:
+      upcoming.startIn > 0 ? { seconds: Math.ceil(upcoming.startIn) } : null,
+  });
+}
+
 export const notifications: NotificationsService = {
   subscribeToPhaseChanges,
   notifyDriver,
+  notifyGreenPhase,
 };


### PR DESCRIPTION
## Summary
- detect current green window in `getUpcomingPhase`
- add `notifyGreenPhase` service and schedule checks on app start
- document green-phase notifications

## Testing
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b156792a488323b1e207b782ad13ed