### PR TITLE
feat: add log viewer and refine exports

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import CycleFormModal from './src/features/traffic/ui/CycleFormModal';
 import SpeedBanner from './src/features/navigation/ui/SpeedBanner';
 import MapViewWrapper from './src/ui/MapViewWrapper';
 import MenuContainer from './src/ui/MenuContainer';
+import LogViewer from './src/features/logs/LogViewer';
 import { supabase } from './src/services/supabase';
 import { useSupabaseData } from './src/hooks/useSupabaseData';
 import { useMenu } from './src/hooks/useMenu';
@@ -73,6 +74,7 @@ export default function App(): JSX.Element {
     useMenu(false);
   const [themeName, setThemeName] = useState(themeNameValue);
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const [logsVisible, setLogsVisible] = useState(false);
 
   useEffect(() => {
     if (!supabaseError) return;
@@ -120,6 +122,11 @@ export default function App(): JSX.Element {
     analytics.trackEvent('settings_change');
     hideMenu();
     setSettingsVisible(true);
+  };
+
+  const handleLogs = () => {
+    hideMenu();
+    setLogsVisible(true);
   };
 
   useEffect(() => {
@@ -256,6 +263,7 @@ export default function App(): JSX.Element {
         onStartNavigation={onStartNavigation}
         onClearRoute={onClearRoute}
         onAddLight={handleAddLight}
+        onLogs={handleLogs}
         onSettings={handleSettings}
       />
       {lightModal && (
@@ -277,6 +285,10 @@ export default function App(): JSX.Element {
         visible={settingsVisible}
         onClose={() => setSettingsVisible(false)}
         onTheme={(t) => setThemeName(t)}
+      />
+      <LogViewer
+        visible={logsVisible}
+        onClose={() => setLogsVisible(false)}
       />
     </View>
   );

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Streamlined registry manager exports and covered them with tests.
+- Added log viewer screen to inspect `data/app.log` from the menu.
 - Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import * as api from '../index';
+
+describe('index exports', () => {
+  it('exposes registry helpers', () => {
+    expect(typeof api.createNavigation).toBe('function');
+    expect(typeof api.getRegistry).toBe('function');
+  });
+});

--- a/src/features/logs/AGENTS.md
+++ b/src/features/logs/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+Guidelines for the log viewing feature.
+
+- Use functional React components with `StyleSheet.create` for styles.
+- Include tests alongside components to verify rendered output.
+- After changes run:
+  ```bash
+  pre-commit run --files <files>
+  npm test -- --coverage
+  ```

--- a/src/features/logs/LogViewer.tsx
+++ b/src/features/logs/LogViewer.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Modal,
+  View,
+  ScrollView,
+  Text,
+  Button,
+  StyleSheet,
+} from 'react-native';
+import * as FileSystem from 'expo-file-system';
+
+export interface LogViewerProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function LogViewer({ visible, onClose }: LogViewerProps) {
+  const [lines, setLines] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!visible) return;
+    FileSystem.readAsStringAsync('data/app.log')
+      .then((content) => setLines(content.split('\n').filter((l) => l.length)))
+      .catch(() => setLines([]));
+  }, [visible]);
+
+  return (
+    <Modal transparent visible={visible} animationType="slide">
+      <View style={styles.container}>
+        <ScrollView style={styles.scroll}>
+          {lines.map((line, i) => (
+            <Text key={i} style={styles.line}>
+              {line}
+            </Text>
+          ))}
+        </ScrollView>
+        <Button title="Close" onPress={onClose} />
+      </View>
+    </Modal>
+  );
+}
+
+const BG = 'white';
+const styles = StyleSheet.create({
+  container: { backgroundColor: BG, flex: 1, padding: 16 },
+  line: { fontFamily: 'monospace', fontSize: 12 },
+  scroll: { flex: 1, marginBottom: 8 },
+});

--- a/src/features/logs/__tests__/LogViewer.test.tsx
+++ b/src/features/logs/__tests__/LogViewer.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+jest.mock('expo-file-system', () => ({
+  readAsStringAsync: jest.fn().mockResolvedValue('a\nb'),
+}));
+
+jest.mock('react-native', () => ({
+  Modal: 'Modal',
+  View: 'View',
+  ScrollView: 'ScrollView',
+  Text: 'Text',
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    React.createElement('Text', { onPress }, title),
+  StyleSheet: { create: () => ({}), flatten: () => ({}) },
+}));
+
+import LogViewer from '../LogViewer';
+
+describe('LogViewer', () => {
+  it('renders log lines', async () => {
+    const { findByText } = render(<LogViewer visible onClose={() => {}} />);
+    expect(await findByText('a')).toBeTruthy();
+    expect(await findByText('b')).toBeTruthy();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
 export { cloneNavigationState } from './features/navigation/cloneNavigationState';
 export { createNavigation, initialState } from './navigationFactory';
-export * from './registryManager';
+export {
+  createRegistryManager,
+  setRegistry,
+  initRegistry,
+  getRegistry,
+  resetRegistry,
+  getCommands,
+  getProcessors,
+  getSources,
+  getStores,
+} from './registryManager';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,6 +6,7 @@
     "startNavigation": "Start Navigation",
     "clearRoute": "Clear Route",
     "addLight": "Add Light",
+    "logs": "Logs",
     "settings": "Settings"
   },
   "validation": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -6,6 +6,7 @@
     "startNavigation": "Начать навигацию",
     "clearRoute": "Очистить маршрут",
     "addLight": "Добавить светофор",
+    "logs": "Логи",
     "settings": "Настройки"
   },
   "validation": {

--- a/src/ui/MainMenu.tsx
+++ b/src/ui/MainMenu.tsx
@@ -12,6 +12,7 @@ export interface MainMenuProps {
   onStartNavigation: () => void;
   onClearRoute: () => void;
   onAddLight: () => void;
+  onLogs: () => void;
   onSettings: () => void;
 }
 
@@ -20,6 +21,7 @@ export default function MainMenu({
   onStartNavigation,
   onClearRoute,
   onAddLight,
+  onLogs,
   onSettings,
 }: MainMenuProps) {
   const { isPremium } = usePremium();
@@ -37,6 +39,9 @@ export default function MainMenu({
           <Text style={styles.text}>{i18n.t('menu.addLight')}</Text>
         </TouchableOpacity>
       ) : null}
+      <TouchableOpacity onPress={onLogs} style={styles.item}>
+        <Text style={styles.text}>{i18n.t('menu.logs')}</Text>
+      </TouchableOpacity>
       <TouchableOpacity onPress={onSettings} style={styles.item}>
         <Text style={styles.text}>{i18n.t('menu.settings')}</Text>
       </TouchableOpacity>

--- a/src/ui/MenuContainer.tsx
+++ b/src/ui/MenuContainer.tsx
@@ -8,6 +8,7 @@ interface Props {
   onStartNavigation: () => void;
   onClearRoute: () => void;
   onAddLight: () => void;
+  onLogs: () => void;
   onSettings: () => void;
 }
 
@@ -17,6 +18,7 @@ export default function MenuContainer({
   onStartNavigation,
   onClearRoute,
   onAddLight,
+  onLogs,
   onSettings,
 }: Props): JSX.Element {
   return (
@@ -26,6 +28,7 @@ export default function MenuContainer({
         onStartNavigation={onStartNavigation}
         onClearRoute={onClearRoute}
         onAddLight={onAddLight}
+        onLogs={onLogs}
         onSettings={onSettings}
       />
       <TouchableOpacity

--- a/src/ui/__tests__/MainMenu.test.tsx
+++ b/src/ui/__tests__/MainMenu.test.tsx
@@ -21,11 +21,13 @@ describe('MainMenu', () => {
         onStartNavigation={noop}
         onClearRoute={noop}
         onAddLight={noop}
+        onLogs={noop}
         onSettings={noop}
       />,
     );
     expect(getByTestId('main-menu')).toBeTruthy();
     expect(getByText('Start Navigation')).toBeTruthy();
+    expect(getByText('Logs')).toBeTruthy();
   });
 
   it('returns null when not visible', () => {
@@ -35,6 +37,7 @@ describe('MainMenu', () => {
         onStartNavigation={noop}
         onClearRoute={noop}
         onAddLight={noop}
+        onLogs={noop}
         onSettings={noop}
       />,
     );

--- a/src/ui/__tests__/MenuContainer.test.tsx
+++ b/src/ui/__tests__/MenuContainer.test.tsx
@@ -21,6 +21,7 @@ describe('MenuContainer', () => {
         onStartNavigation={noop}
         onClearRoute={noop}
         onAddLight={noop}
+        onLogs={noop}
         onSettings={noop}
       />,
     );


### PR DESCRIPTION
## Summary
- show app log file with new `LogViewer`
- link log viewer from menu
- export registry helpers explicitly for easier testing

## Testing
- `pnpm lint --format unix`
- `npm test -- --coverage`
- `pnpm test:vitest` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b159ba5de48323af9fed7e7dca6fdd