### PR TITLE
refactor: move traffic services into feature and expose core factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Open a pull request on GitHub and request a review.
  
 - Streamlined registry manager exports and covered them with tests.
 - Added log viewer screen to inspect `data/app.log` from the menu.
-
-- Added green-phase notifications with periodic checks at st
+- Added notifications for upcoming green phases.
 - Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.

--- a/src/features/traffic/hooks/__tests__/useLightDetector.test.ts
+++ b/src/features/traffic/hooks/__tests__/useLightDetector.test.ts
@@ -6,7 +6,7 @@ import { runModelOnImageMock as runModelOnImageMockRaw } from 'tflite-react-nati
 import type { CameraCapturedPicture } from 'expo-camera';
 const runModelOnImageMock = runModelOnImageMockRaw as jest.Mock;
 
-jest.mock('../../../../services/lightCycleUploader', () => ({
+jest.mock('../../services/lightCycleUploader', () => ({
   uploadLightCycle: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/features/traffic/hooks/useLightDetector.ts
+++ b/src/features/traffic/hooks/useLightDetector.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Tflite from 'tflite-react-native';
 import type { CameraView, CameraCapturedPicture } from 'expo-camera';
 import { finalizePhase, ColorPhase } from '../services/colorPhases';
-import { uploadLightCycle } from '../../../services/lightCycleUploader';
+import { uploadLightCycle } from '../services/lightCycleUploader';
 
 export interface TrafficLightDetection {
   color: 'red' | 'yellow' | 'green';

--- a/src/features/traffic/services/AGENTS.md
+++ b/src/features/traffic/services/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+Guidelines for traffic services.
+
+- Keep modules small and side-effect free.
+- Tests live alongside the services they cover.
+- Run `pre-commit run --files <files>` and `npm test -- --coverage` after changes.

--- a/src/features/traffic/services/lightCycleUploader.test.ts
+++ b/src/features/traffic/services/lightCycleUploader.test.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { uploadLightCycle } from '../lightCycleUploader';
-import { uploadCycle } from '../uploadLightData';
-import type { ColorPhase } from '../../features/traffic/services/colorPhases';
+import { uploadLightCycle } from './lightCycleUploader';
+import { uploadCycle } from './uploadLightData';
+import type { ColorPhase } from './colorPhases';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
   jest.requireActual(
@@ -9,7 +9,7 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   ),
 );
 
-jest.mock('../uploadLightData', () => ({
+jest.mock('./uploadLightData', () => ({
   uploadCycle: jest.fn(),
 }));
 

--- a/src/features/traffic/services/lightCycleUploader.ts
+++ b/src/features/traffic/services/lightCycleUploader.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { uploadCycle, Phase } from './uploadLightData';
-import { ColorPhase } from '../features/traffic/services/colorPhases';
+import { ColorPhase } from './colorPhases';
 
 export async function uploadLightCycle(
   light: { id: number | string; lat: number; lon: number } | null,

--- a/src/features/traffic/services/phaseSync.ts
+++ b/src/features/traffic/services/phaseSync.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { network } from './network';
-import type { PhaseRecord, PhaseSync } from '../interfaces/phaseSync';
+import { network } from '../../../services/network';
+import type { PhaseRecord, PhaseSync } from '../../../interfaces/phaseSync';
 
 export const STORAGE_KEY = 'voicePhases';
 const ENDPOINT = 'https://example.com/api/phases';

--- a/src/features/traffic/services/uploadLightData.test.ts
+++ b/src/features/traffic/services/uploadLightData.test.ts
@@ -1,11 +1,11 @@
-jest.mock('../supabase', () => ({
+jest.mock('../../../services/supabase', () => ({
   supabase: { from: jest.fn() },
 }));
-jest.mock('../logger', () => ({ log: jest.fn() }));
+jest.mock('../../../services/logger', () => ({ log: jest.fn() }));
 
-import { uploadCycle } from '../uploadLightData';
-import { supabase } from '../supabase';
-import { log } from '../logger';
+import { uploadCycle } from './uploadLightData';
+import { supabase } from '../../../services/supabase';
+import { log } from '../../../services/logger';
 
 describe('uploadCycle', () => {
   it('logs and throws on insert error', async () => {

--- a/src/features/traffic/services/uploadLightData.ts
+++ b/src/features/traffic/services/uploadLightData.ts
@@ -1,5 +1,5 @@
-import { supabase } from './supabase';
-import { log } from './logger';
+import { supabase } from '../../../services/supabase';
+import { log } from '../../../services/logger';
 
 export interface Phase {
   color: string;

--- a/src/features/traffic/ui/__tests__/useVoicePhaseLogger.test.ts
+++ b/src/features/traffic/ui/__tests__/useVoicePhaseLogger.test.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { parseVoiceResult } from '../useVoicePhaseLogger';
-import { phaseSync, STORAGE_KEY } from '../../../../services/phaseSync';
+import { phaseSync, STORAGE_KEY } from '../../services/phaseSync';
 import { network } from '../../../../services/network';
 
 jest.mock(

--- a/src/features/traffic/ui/useVoicePhaseLogger.ts
+++ b/src/features/traffic/ui/useVoicePhaseLogger.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Voice from 'expo-voice';
 import type { PhaseRecord } from '../../../interfaces/phaseSync';
-import { STORAGE_KEY } from '../../../services/phaseSync';
+import { STORAGE_KEY } from '../services/phaseSync';
 
 const COLOR_RE = /(red|yellow|green)/i;
 const TIME_RE = /(\d+(?:\.\d+)?)/;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,10 @@
+import { createCore, createNavigation } from './index';
+
+describe('createCore', () => {
+  it('exposes navigation helpers and registry functions', () => {
+    const core = createCore();
+    expect(core.createNavigation).toBe(createNavigation);
+    expect(typeof core.createRegistryManager).toBe('function');
+    expect(typeof core.getRegistry).toBe('function');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,19 @@
-export { cloneNavigationState } from './features/navigation/cloneNavigationState';
-export { createNavigation, initialState } from './navigationFactory';
-export {
+import { cloneNavigationState } from './features/navigation/cloneNavigationState';
+import { createNavigation, initialState } from './navigationFactory';
+import * as registry from './registryManager';
+
+export function createCore() {
+  return {
+    cloneNavigationState,
+    createNavigation,
+    initialState,
+    ...registry,
+  };
+}
+
+export { cloneNavigationState, createNavigation, initialState };
+
+export const {
   createRegistryManager,
   setRegistry,
   initRegistry,
@@ -10,4 +23,4 @@ export {
   getProcessors,
   getSources,
   getStores,
-} from './registryManager';
+} = registry;


### PR DESCRIPTION
## Summary
- relocate traffic light services under `src/features/traffic/services`
- expose `createCore` helper from `src/index.ts` for easier testing
- document traffic service guidelines and note green-phase notifications in README

## Testing
- `pre-commit run --files src/features/traffic/hooks/__tests__/useLightDetector.test.ts src/features/traffic/hooks/useLightDetector.ts src/features/traffic/services/lightCycleUploader.test.ts src/features/traffic/services/lightCycleUploader.ts src/features/traffic/services/phaseSync.ts src/features/traffic/services/uploadLightData.test.ts src/features/traffic/services/uploadLightData.ts src/features/traffic/ui/__tests__/useVoicePhaseLogger.test.ts src/features/traffic/ui/useVoicePhaseLogger.ts src/index.ts src/index.test.ts`
- `pre-commit run --files src/features/traffic/services/AGENTS.md`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b15c7725f48323b5592f13672c7406