### PR TITLE
refactor: rename maneuver panel style

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
- 
+
+- Consolidated traffic services under `src/features/traffic/services` with new guidelines.
 - Streamlined registry manager exports and covered them with tests.
 - Added log viewer screen to inspect `data/app.log` from the menu.
 - Added notifications for upcoming green phases.

--- a/src/features/navigation/ui/DrivingHUD.tsx
+++ b/src/features/navigation/ui/DrivingHUD.tsx
@@ -41,7 +41,7 @@ export default function DrivingHUD({
   }, [maneuver, distance]);
   return (
     <SafeAreaView style={styles.container} pointerEvents="none">
-      <View style={styles.maneuvers}>
+      <View style={styles.maneuverPanel}>
         <Text testID="hud-maneuver" style={styles.text}>
           {maneuver
             ? i18n.t('hud.maneuver', {
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
     backgroundColor: PANEL_BG,
     padding: 8,
   },
-  maneuvers: {
+  maneuverPanel: {
     alignSelf: 'center',
     backgroundColor: PANEL_BG,
     borderRadius: 6,


### PR DESCRIPTION
## Summary
- rename maneuvers style key to maneuverPanel
- document traffic services consolidation

## Testing
- `pre-commit run --files src/features/navigation/ui/DrivingHUD.tsx README.md`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b160b3c2048323b745edd487d9ad6e