### PR TITLE
docs: document centralized service tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Open a pull request on GitHub and request a review.
 ## Recent changes
 
 
+- Driving HUD now reacts to speech setting toggles for voice guidance.
 - Renamed maneuver panel style for consistent naming.
 - Consolidated traffic services under `src/features/traffic/services` with new guidelines.
 - Streamlined registry manager exports and covered them with tests.

--- a/src/services/AGENTS.md
+++ b/src/services/AGENTS.md
@@ -4,6 +4,6 @@ Guidelines for code in `src/services`.
 
 - Provide small, focused helpers for networking, logging, and analytics.
 - Export typed interfaces from `src/interfaces` where possible.
-- Place service tests in `__tests__/` beside the code.
+- Service tests reside in `src/services/__tests__` to share common mocks.
 - Mock `fetch` and external APIs in tests; avoid real network calls.
 - Run `pre-commit run --files <files>` and `npm test -- --coverage` after changes.


### PR DESCRIPTION
## Summary
- document that service tests live under `src/services/__tests__`
- note new Driving HUD speech setting reaction in README

## Testing
- `pre-commit run --files README.md src/services/AGENTS.md`
- `pnpm lint --format unix`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b16452f65c832397f626761b0c5e10