### PR TITLE
test(navigation): toggle speech setting

### DIFF
--- a/src/features/navigation/ui/__tests__/DrivingHUD.test.tsx
+++ b/src/features/navigation/ui/__tests__/DrivingHUD.test.tsx
@@ -86,4 +86,34 @@ describe('DrivingHUD', () => {
       expect(Speech.speak).toHaveBeenCalledWith('Turn left in 100 m'),
     );
   });
+
+  it('calls Speech.speak once when speechEnabled goes from false to true', async () => {
+    speechState.speechEnabled = false;
+    const { rerender } = render(
+      <DrivingHUD
+        maneuver="Turn left"
+        distance={100}
+        street=""
+        eta={0}
+        speed={0}
+      />,
+    );
+    expect(Speech.speak).not.toHaveBeenCalled();
+
+    speechState.speechEnabled = true;
+    rerender(
+      <DrivingHUD
+        maneuver="Turn left"
+        distance={100}
+        street=""
+        eta={0}
+        speed={0}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(Speech.speak).toHaveBeenCalledTimes(1);
+      expect(Speech.speak).toHaveBeenCalledWith('Turn left in 100 m');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add isolated DrivingHUD test that mocks expo-speech and verifies Speech.speak when speechEnabled toggles on

## Testing
- `pre-commit run --files src/features/navigation/ui/__tests__/DrivingHUD.test.tsx`
- `pnpm lint --format unix src/features/navigation/ui/__tests__/DrivingHUD.test.tsx`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b1685fbf7c8323a3642ddf28be589a