### PR TITLE
fix(navigation): guard NaN speed and allow registry injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - refactor: rename maneuver panel style
 - feat: schedule notifications for upcoming green phases
+- fix: guard NaN speeds in navigation advisor
 
 ## 2025-09
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Open a pull request on GitHub and request a review.
 ## Recent changes
 
 
+- Navigation advisor treats `NaN` speeds as `0` to avoid invalid recommendations.
+- `createCore` now accepts a custom registry for improved testability.
 - Driving HUD now reacts to speech setting toggles for voice guidance.
 - Renamed maneuver panel style for consistent naming.
 - Consolidated traffic services under `src/features/traffic/services` with new guidelines.

--- a/src/features/navigation/advisor.test.ts
+++ b/src/features/navigation/advisor.test.ts
@@ -45,6 +45,20 @@ describe('advisor pickSpeed', () => {
     expect(res.reason).toBe('no-data');
     expect(res.recommended).toBe(52);
   });
+
+  it('handles NaN speed as zero', () => {
+    const withNaN = pickSpeed(
+      0,
+      [{ light, cycle: baseCycle, dist_m: 500, dirForDriver: 'MAIN' }],
+      Number.NaN,
+    );
+    const withZero = pickSpeed(
+      0,
+      [{ light, cycle: baseCycle, dist_m: 500, dirForDriver: 'MAIN' }],
+      0,
+    );
+    expect(withNaN).toEqual(withZero);
+  });
 });
 
 describe('advisor hysteresis', () => {

--- a/src/features/navigation/advisor.ts
+++ b/src/features/navigation/advisor.ts
@@ -14,10 +14,11 @@ export function pickSpeed(
   recommended: number;
   reason: 'nearest-green' | 'global-score' | 'no-data';
 } {
+  const vReal = Number.isFinite(vRealKmh) ? vRealKmh : 0;
   const candidates = Array.from({ length: 61 }, (_, i) => 20 + i);
   if (!lightsOnRoute.length)
     return {
-      recommended: Math.max(20, Math.min(80, Math.round(vRealKmh || 50))),
+      recommended: Math.max(20, Math.min(80, Math.round(vReal || 50))),
       reason: 'no-data',
     };
 
@@ -46,7 +47,7 @@ export function pickSpeed(
       else if (i === 0) okNearest = false;
     }
     const finalScore =
-      (okNearest ? 10000 : 0) + score - Math.abs(v - vRealKmh) * 2;
+      (okNearest ? 10000 : 0) + score - Math.abs(v - vReal) * 2;
     if (finalScore > best.score)
       best = {
         v,

--- a/src/features/navigation/ui/DrivingHUD.tsx
+++ b/src/features/navigation/ui/DrivingHUD.tsx
@@ -27,9 +27,10 @@ export default function DrivingHUD({
   const speedKmh = Math.round(speed || 0);
   const limit = speedLimit ? Math.round(speedLimit) : '--';
   const spoken = useRef<string | undefined>();
+  const enabled = speechEnabled;
 
   useEffect(() => {
-    if (speechEnabled && maneuver && spoken.current !== maneuver) {
+    if (enabled && maneuver && spoken.current !== maneuver) {
       Speech.speak(
         i18n.t('hud.maneuver', {
           maneuver,
@@ -38,7 +39,7 @@ export default function DrivingHUD({
       );
       spoken.current = maneuver;
     }
-  }, [speechEnabled, maneuver, distance]);
+  }, [enabled, maneuver, distance]);
   return (
     <SafeAreaView style={styles.container} pointerEvents="none">
       <View style={styles.maneuverPanel}>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,4 +7,12 @@ describe('createCore', () => {
     expect(typeof core.createRegistryManager).toBe('function');
     expect(typeof core.getRegistry).toBe('function');
   });
+
+  it('allows injecting custom registry', () => {
+    const custom = {
+      createRegistryManager: jest.fn(),
+    } as unknown as typeof import('./registryManager');
+    const core = createCore(custom);
+    expect(core.createRegistryManager).toBe(custom.createRegistryManager);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@ import { cloneNavigationState } from './features/navigation/cloneNavigationState
 import { createNavigation, initialState } from './navigationFactory';
 import * as registry from './registryManager';
 
-export function createCore() {
+export function createCore(customRegistry: typeof registry = registry) {
   return {
     cloneNavigationState,
     createNavigation,
     initialState,
-    ...registry,
+    ...customRegistry,
   };
 }
 


### PR DESCRIPTION
## Summary
- guard NaN speed values in navigation advisor
- allow injecting custom registry for createCore
- document change and handle speech effect dependency

## Testing
- `pnpm lint --format unix`
- `CI=1 pnpm test --coverage`
- `pnpm audit`


------
https://chatgpt.com/codex/tasks/task_e_68b1839e1b988323a28ee05fd6f038ab