### PR TITLE
docs: highlight HUD speech-setting toggle reaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
-
+- Driving HUD reacts to speech-setting toggles.
 - Navigation advisor treats `NaN` speeds as `0` to avoid invalid recommendations.
 - `createCore` now accepts a custom registry for improved testability.
-- Driving HUD now reacts to speech setting toggles for voice guidance.
 - Renamed maneuver panel style for consistent naming.
 - Consolidated traffic services under `src/features/traffic/services` with new guidelines.
 - Streamlined registry manager exports and covered them with tests.


### PR DESCRIPTION
## Summary
- ensure README recent changes list starts with HUD reaction to speech-setting toggles

## Testing
- `pre-commit run --files README.md`
- `pnpm lint --format unix`
- `pnpm test --coverage --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b185b73dfc8323ae4502a2e302cc0e