### PR TITLE
test: cover notifications schedule

### DIFF
--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -35,7 +35,7 @@ describe('notifications service', () => {
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('notifies upcoming green phase', async () => {
+  it('schedules notification when startIn > 0', async () => {
     (getUpcomingPhase as jest.Mock).mockResolvedValueOnce({
       direction: 'MAIN',
       startIn: 5,
@@ -45,5 +45,11 @@ describe('notifications service', () => {
       content: { title: 'Upcoming green', body: 'MAIN in 5s' },
       trigger: { seconds: 5 },
     });
+  });
+
+  it('does not schedule when no upcoming phase', async () => {
+    (getUpcomingPhase as jest.Mock).mockResolvedValueOnce(null);
+    await notifyGreenPhase('1');
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ensure notifications for upcoming phase schedule when startIn > 0
- avoid scheduling when getUpcomingPhase returns null

## Testing
- `pre-commit run --files src/services/__tests__/notifications.test.ts`
- `pnpm lint src/services/__tests__/notifications.test.ts --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b18b60e3e883238be6ba4337c6dc89