### PR TITLE
feat: add lead time setting for notifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,6 +31,7 @@ import {
   computeRecommendation,
   LightOnRoute,
 } from './src';
+import { loadLeadTimeSec, leadTimeSec } from './src/state/leadTime';
 import type { Light, LightCycle } from './src/domain/types';
 
 interface Car {
@@ -133,6 +134,7 @@ export default function App(): JSX.Element {
   useEffect(() => {
     loadTheme().then(() => setThemeName(themeNameValue));
     loadSpeechEnabled();
+    loadLeadTimeSec();
   }, []);
 
   useEffect(() => {
@@ -143,7 +145,7 @@ export default function App(): JSX.Element {
   useEffect(() => {
     const id = setInterval(() => {
       lights.forEach((l) => {
-        void notifyGreenPhase(l.id);
+        void notifyGreenPhase(l.id, leadTimeSec);
       });
     }, 30000);
     return () => clearInterval(id);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - refactor: rename maneuver panel style
 - feat: schedule notifications for upcoming green phases
+- feat: allow lead-time offset for green-phase notifications
 - fix: guard NaN speeds in navigation advisor
 
 ## 2025-09

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Open a pull request on GitHub and request a review.
 - Streamlined registry manager exports and covered them with tests.
 - Added log viewer screen to inspect `data/app.log` from the menu.
 - Added notifications for upcoming green phases.
+- Added lead-time setting for green-phase notifications.
 - Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.

--- a/src/interfaces/notifications.ts
+++ b/src/interfaces/notifications.ts
@@ -7,5 +7,5 @@ export interface PhaseEmitter {
 export interface NotificationsService {
   subscribeToPhaseChanges(emitter: PhaseEmitter): void;
   notifyDriver(phase: PhaseColor): Promise<void>;
-  notifyGreenPhase(lightId: string): Promise<void>;
+  notifyGreenPhase(lightId: string, leadTimeSec?: number): Promise<void>;
 }

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -47,6 +47,18 @@ describe('notifications service', () => {
     });
   });
 
+  it('honors lead time', async () => {
+    (getUpcomingPhase as jest.Mock).mockResolvedValueOnce({
+      direction: 'SIDE',
+      startIn: 10,
+    });
+    await notifyGreenPhase('2', 4);
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: { title: 'Upcoming green', body: 'SIDE in 6s' },
+      trigger: { seconds: 6 },
+    });
+  });
+
   it('does not schedule when no upcoming phase', async () => {
     (getUpcomingPhase as jest.Mock).mockResolvedValueOnce(null);
     await notifyGreenPhase('1');

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -22,16 +22,19 @@ export function subscribeToPhaseChanges(emitter: PhaseEmitter): void {
   });
 }
 
-export async function notifyGreenPhase(lightId: string): Promise<void> {
+export async function notifyGreenPhase(
+  lightId: string,
+  leadTimeSec = 0,
+): Promise<void> {
   const upcoming = await getUpcomingPhase(lightId);
   if (!upcoming) return;
+  const startIn = Math.max(0, upcoming.startIn - leadTimeSec);
   await Notifications.scheduleNotificationAsync({
     content: {
       title: 'Upcoming green',
-      body: `${upcoming.direction} in ${Math.round(upcoming.startIn)}s`,
+      body: `${upcoming.direction} in ${Math.round(startIn)}s`,
     },
-    trigger:
-      upcoming.startIn > 0 ? { seconds: Math.ceil(upcoming.startIn) } : null,
+    trigger: upcoming.startIn > 0 ? { seconds: Math.ceil(startIn) } : null,
   });
 }
 

--- a/src/state/leadTime.test.ts
+++ b/src/state/leadTime.test.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as lead from './leadTime';
+
+const { setLeadTimeSec, loadLeadTimeSec } = lead;
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('@react-native-async-storage/async-storage/jest/async-storage-mock');
+});
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('leadTime state', () => {
+  it('loads value from storage', async () => {
+    await AsyncStorage.setItem('lead_time_sec', '3');
+    await loadLeadTimeSec();
+    expect(lead.leadTimeSec).toBe(3);
+  });
+
+  it('saves value to storage', async () => {
+    await setLeadTimeSec(4);
+    expect(await AsyncStorage.getItem('lead_time_sec')).toBe('4');
+  });
+});

--- a/src/state/leadTime.ts
+++ b/src/state/leadTime.ts
@@ -1,0 +1,16 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = 'lead_time_sec';
+
+export let leadTimeSec = 0;
+
+export async function setLeadTimeSec(value: number): Promise<void> {
+  leadTimeSec = value;
+  await AsyncStorage.setItem(KEY, value.toString());
+}
+
+export async function loadLeadTimeSec(): Promise<void> {
+  const stored = await AsyncStorage.getItem(KEY);
+  const parsed = stored ? parseInt(stored, 10) : NaN;
+  if (!Number.isNaN(parsed)) leadTimeSec = parsed;
+}

--- a/src/ui/Settings.tsx
+++ b/src/ui/Settings.tsx
@@ -1,7 +1,16 @@
 import React, { useState } from 'react';
-import { Modal, View, StyleSheet, Switch, Text, Button } from 'react-native';
+import {
+  Modal,
+  View,
+  StyleSheet,
+  Switch,
+  Text,
+  Button,
+  TextInput,
+} from 'react-native';
 import { setTheme, theme } from '../state/theme';
 import { speechEnabled, setSpeechEnabled } from '../state/speech';
+import { leadTimeSec, setLeadTimeSec } from '../state/leadTime';
 
 export interface SettingsProps {
   visible: boolean;
@@ -16,6 +25,7 @@ export default function Settings({
 }: SettingsProps): JSX.Element {
   const [voice, setVoice] = useState(speechEnabled);
   const [dark, setDark] = useState(theme === 'dark');
+  const [lead, setLead] = useState(String(leadTimeSec));
 
   const toggleTheme = async (v: boolean) => {
     setDark(v);
@@ -27,6 +37,12 @@ export default function Settings({
   const toggleSpeech = async (v: boolean) => {
     setVoice(v);
     await setSpeechEnabled(v);
+  };
+
+  const changeLead = async (v: string) => {
+    setLead(v);
+    const parsed = parseInt(v, 10);
+    if (!Number.isNaN(parsed)) await setLeadTimeSec(parsed);
   };
 
   return (
@@ -48,12 +64,23 @@ export default function Settings({
             onValueChange={toggleSpeech}
           />
         </View>
+        <View style={styles.row}>
+          <Text style={styles.label}>Lead time (s)</Text>
+          <TextInput
+            testID="lead-input"
+            style={styles.input}
+            keyboardType="numeric"
+            value={lead}
+            onChangeText={changeLead}
+          />
+        </View>
         <Button title="Close" onPress={onClose} />
       </View>
     </Modal>
   );
 }
 const BG_COLOR = 'white';
+const BORDER_COLOR = '#ccc';
 
 const styles = StyleSheet.create({
   container: {
@@ -61,6 +88,13 @@ const styles = StyleSheet.create({
     backgroundColor: BG_COLOR,
     flex: 1,
     justifyContent: 'center',
+  },
+  input: {
+    borderColor: BORDER_COLOR,
+    borderWidth: 1,
+    minWidth: 40,
+    paddingHorizontal: 4,
+    textAlign: 'center',
   },
   label: {
     marginRight: 8,

--- a/src/ui/__tests__/Settings.test.tsx
+++ b/src/ui/__tests__/Settings.test.tsx
@@ -8,6 +8,7 @@ jest.mock('react-native', () => ({
   StyleSheet: { create: () => ({}), flatten: () => ({}) },
   Switch: 'Switch',
   Text: 'Text',
+  TextInput: 'TextInput',
 }));
 
 jest.mock('../../state/theme', () => ({ setTheme: jest.fn(), theme: 'light' }));
@@ -15,6 +16,11 @@ const setSpeechEnabled = jest.fn();
 jest.mock('../../state/speech', () => ({
   speechEnabled: true,
   setSpeechEnabled: (v: boolean) => setSpeechEnabled(v),
+}));
+const setLeadTimeSec = jest.fn();
+jest.mock('../../state/leadTime', () => ({
+  leadTimeSec: 0,
+  setLeadTimeSec: (v: number) => setLeadTimeSec(v),
 }));
 
 import Settings from '../Settings';
@@ -31,5 +37,7 @@ describe('Settings', () => {
     expect(onTheme).toHaveBeenCalledWith('dark');
     fireEvent(getByTestId('speech-toggle'), 'valueChange', false);
     expect(setSpeechEnabled).toHaveBeenCalledWith(false);
+    fireEvent.changeText(getByTestId('lead-input'), '7');
+    expect(setLeadTimeSec).toHaveBeenCalledWith(7);
   });
 });


### PR DESCRIPTION
## Summary
- allow setting lead time for upcoming green phase notifications
- expose lead time input on settings screen and persist to storage
- add tests for lead time

## Testing
- `pre-commit run --files src/ui/Settings.tsx`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6a03b808323b9254723273ad7cc