### PR TITLE
test: update notification lead-time direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Open a pull request on GitHub and request a review.
 - Added log viewer screen to inspect `data/app.log` from the menu.
 - Added notifications for upcoming green phases.
 - Added lead-time setting for green-phase notifications.
+- Persisted lead-time preference across sessions.
 - Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.

--- a/src/services/__tests__/AGENTS.md
+++ b/src/services/__tests__/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS
+
+Guidelines for tests under `src/services/__tests__`.
+
+- Use Jest with manual mocks; avoid real network or notification calls.
+- Prefer `jest.mock` for services like `expo-notifications` and fetch helpers.
+- Run `pre-commit run --files <files>` and `pnpm test -- --coverage` after editing tests.

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -49,12 +49,12 @@ describe('notifications service', () => {
 
   it('honors lead time', async () => {
     (getUpcomingPhase as jest.Mock).mockResolvedValueOnce({
-      direction: 'SIDE',
+      direction: 'SECONDARY',
       startIn: 10,
     });
     await notifyGreenPhase('2', 4);
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-      content: { title: 'Upcoming green', body: 'SIDE in 6s' },
+      content: { title: 'Upcoming green', body: 'SECONDARY in 6s' },
       trigger: { seconds: 6 },
     });
   });


### PR DESCRIPTION
## Summary
- document persisted lead-time preference in README
- guide service tests via AGENTS
- expect SECONDARY direction in notification lead-time test

## Testing
- `pre-commit run --files README.md src/services/__tests__/notifications.test.ts src/services/__tests__/AGENTS.md`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b1e09837c0832384fe11dca86fb3a8