### PR TITLE
feat: add unsubscribe callback for phase changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ New contributors can start by exploring the folders below to see how the app is 
 - Start with [`README.md`](README.md) and [`CHANGELOG.md`](CHANGELOG.md) to see recent changes.
 - Navigation helpers live in `src/features/navigation` and are re-exported from `src/index.ts`.
 - Use `createNavigation()` from `src/index.ts` to obtain test-friendly navigation helpers.
+- `createCore({ navigation, registry })` in `src/index.ts` lets you inject test doubles for navigation or registry logic.
 - Tests sit next to code; see `src/features/navigation/__tests__` for examples.
 
 Service interfaces are named `SupabaseService`, `AnalyticsService`, etc., and live in `src/interfaces/`.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Open a pull request on GitHub and request a review.
 - Added notifications for upcoming green phases.
 - Added lead-time setting for green-phase notifications.
 - Persisted lead-time preference across sessions.
+- `subscribeToPhaseChanges` now returns an unsubscribe callback to remove listeners.
 - Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.
 - Added modular GPT service with API client, prompt formatter, and utilities.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,20 @@ describe('createCore', () => {
     const custom = {
       createRegistryManager: jest.fn(),
     } as unknown as typeof import('./registryManager');
-    const core = createCore(custom);
+    const core = createCore({ registry: custom });
     expect(core.createRegistryManager).toBe(custom.createRegistryManager);
+  });
+
+  it('allows injecting custom navigation', () => {
+    const navigation = {
+      createNavigation: jest.fn(),
+      initialState: { foo: 'bar' },
+    } as unknown as {
+      createNavigation: typeof createNavigation;
+      initialState: typeof import('./navigationFactory').initialState;
+    };
+    const core = createCore({ navigation });
+    expect(core.createNavigation).toBe(navigation.createNavigation);
+    expect(core.initialState).toBe(navigation.initialState);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,29 @@
 import { cloneNavigationState } from './features/navigation/cloneNavigationState';
-import { createNavigation, initialState } from './navigationFactory';
+import * as navigationFactory from './navigationFactory';
 import * as registry from './registryManager';
 
-export function createCore(customRegistry: typeof registry = registry) {
+interface CoreDeps {
+  navigation?: {
+    createNavigation: typeof navigationFactory.createNavigation;
+    initialState: typeof navigationFactory.initialState;
+  };
+  registry?: typeof registry;
+}
+
+export function createCore({
+  navigation = navigationFactory,
+  registry: registryDep = registry,
+}: CoreDeps = {}) {
   return {
     cloneNavigationState,
-    createNavigation,
-    initialState,
-    ...customRegistry,
+    createNavigation: navigation.createNavigation,
+    initialState: navigation.initialState,
+    ...registryDep,
   };
 }
 
-export { cloneNavigationState, createNavigation, initialState };
+export const { createNavigation, initialState } = navigationFactory;
+export { cloneNavigationState };
 
 export const {
   createRegistryManager,

--- a/src/interfaces/notifications.ts
+++ b/src/interfaces/notifications.ts
@@ -2,10 +2,11 @@ export type PhaseColor = 'red' | 'yellow' | 'green';
 
 export interface PhaseEmitter {
   on(event: 'phase', listener: (phase: PhaseColor) => void): void;
+  off(event: 'phase', listener: (phase: PhaseColor) => void): void;
 }
 
 export interface NotificationsService {
-  subscribeToPhaseChanges(emitter: PhaseEmitter): void;
+  subscribeToPhaseChanges(emitter: PhaseEmitter): () => void;
   notifyDriver(phase: PhaseColor): Promise<void>;
   notifyGreenPhase(lightId: string, leadTimeSec?: number): Promise<void>;
 }

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -30,9 +30,15 @@ describe('notifications service', () => {
 
   it('subscribes to phase changes', () => {
     const emitter = new EventEmitter();
-    subscribeToPhaseChanges(emitter as unknown as PhaseEmitter);
+    const unsubscribe = subscribeToPhaseChanges(
+      emitter as unknown as PhaseEmitter,
+    );
     emitter.emit('phase', 'red');
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    (Notifications.scheduleNotificationAsync as jest.Mock).mockClear();
+    unsubscribe();
+    emitter.emit('phase', 'green');
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
   });
 
   it('schedules notification when startIn > 0', async () => {

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -16,10 +16,14 @@ export async function notifyDriver(phase: PhaseColor): Promise<void> {
   });
 }
 
-export function subscribeToPhaseChanges(emitter: PhaseEmitter): void {
-  emitter.on('phase', (phase: PhaseColor) => {
+export function subscribeToPhaseChanges(emitter: PhaseEmitter): () => void {
+  const listener = (phase: PhaseColor) => {
     void notifyDriver(phase);
-  });
+  };
+  emitter.on('phase', listener);
+  return () => {
+    emitter.off('phase', listener);
+  };
 }
 
 export async function notifyGreenPhase(


### PR DESCRIPTION
## Summary
- allow removing phase change listener via returned callback
- inject navigation and registry into createCore for testing
- document new notification API and clarify onboarding tips

## Testing
- `pre-commit run --files AGENTS.md README.md src/index.test.ts src/index.ts src/interfaces/notifications.ts src/services/__tests__/notifications.test.ts src/services/notifications.ts`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b1f31599c483238b896f1dac9bcddc