### PR TITLE
docs: fix Supabase bullet formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Open a pull request on GitHub and request a review.
 - Added LightStatusBadge component showing upcoming traffic-light phases.
 - Added markup mode toggle for map overlays.
 - Exposed grouped modules in `index.ts` for easier testing.
-- Introduced shared Supabase client (`src/lib/supabase.ts`) and a lights service with CRUD and phase helpers backed by Vitest tests.
+- Introduced shared Supabase client (`src/lib/supabase.ts`) and a lights service with CRUD and phase helpers, backed by Vitest tests.
 - Added lights migration and seed data for traffic-light management.
 - Added `.npmrc` with `shamefully-hoist=false` and expanded npm scripts for development and diagnostics.
 - Pinned Expo, React, React Native, and Metro versions and switched to `pnpm`.


### PR DESCRIPTION
## Summary
- fix line wrapping for Supabase bullet in README

## Testing
- `pre-commit run --files README.md` *(fails: black/isort skipped)*
- `pnpm lint --format unix`
- `pnpm test -- --coverage` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21142b5a48323a47665667d275365