### PR TITLE
docs: update coverage command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Tests live beside the code they verify, and coverage reports are stored under `c
 - `pnpm install` – install dependencies.
 - `pnpm run clean` – reset caches and lockfile.
 - `npx expo start` – launch the development server.
-- `pnpm test -- --coverage` – run the Jest suite with coverage.
+- `pnpm test --coverage` – run the Jest suite with coverage.
 - `pnpm lint` – check JavaScript and TypeScript code style.
 - Node scripts use the [`tsx`](https://github.com/privatenumber/tsx) loader via `node --loader tsx`.
 
@@ -61,7 +61,7 @@ Run these commands before committing:
 ```bash
 pre-commit run --files <files>
 pnpm lint --format unix
-pnpm test -- --coverage
+pnpm test --coverage
 ```
 
 Tests should pass and formatting hooks should run on the changed files. The `test` workflow uploads `coverage/lcov.info` to Codecov.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [docs/API.md](docs/API.md) for available REST endpoints.
 git checkout -b feature/<name>
 pre-commit run --files <files>
 pnpm lint --format unix
-pnpm test -- --coverage
+pnpm test --coverage
 git commit -am "feat: add amazing thing"
 git push origin feature/<name>
 ```
@@ -79,7 +79,7 @@ Open a pull request on GitHub and request a review.
 - Added `clean` script for wiping caches and reinstalling dependencies.
 - Covered invalid JSON and missing type cases in `onMessage` tests.
 - Unified test command across documentation.
-- Dropped coverage npm script; run tests with `pnpm test -- --coverage`.
+- Dropped coverage npm script; run tests with `pnpm test --coverage`.
 - Re-exported `cloneNavigationState` from the navigation feature and removed duplicate implementation.
 - Renamed project heading to "greenWave".
 - Added tests to ensure navigation maneuvers remain isolated between runs.
@@ -164,7 +164,7 @@ npx expo start -c
 Run unit tests:
 
 ```
-pnpm test -- --coverage
+pnpm test --coverage
 ```
 
 ### Database
@@ -216,4 +216,4 @@ pnpm install
 - Expose interfaces from each module's `index.ts` to guide refactors.
 - Supabase and analytics services accept typed config objects.
 - Use the `tsx` loader directly without a build step.
-- Ensure `pnpm test -- --coverage` and `pnpm run lint` pass after each change.
+- Ensure `pnpm test --coverage` and `pnpm run lint` pass after each change.


### PR DESCRIPTION
## Summary
- update test command in docs to `pnpm test --coverage`
- reflect updated coverage command in AGENTS instructions

## Testing
- `pre-commit run --files README.md AGENTS.md`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b23b768024832394fdb022181830bb