### PR TITLE
chore: configure pnpm for expo and make core injectable

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,12 @@
-shamefully-hoist=false
+node-linker=hoisted
+public-hoist-pattern[]=metro
+public-hoist-pattern[]=@expo/*
+public-hoist-pattern[]=expo*
+public-hoist-pattern[]=react-native
+public-hoist-pattern[]=@react-native/*
+public-hoist-pattern[]=@babel/*
+public-hoist-pattern[]=*babel*
+public-hoist-pattern[]=@types/*
+public-hoist-pattern[]=whatwg-*
+ignore-scripts=false
+enable-pre-post-scripts=true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Configured pnpm with hoisted node linker for Expo 53 compatibility and removed `tflite-react-native`.
 - Driving HUD reacts to speech-setting toggles.
 - Navigation advisor treats `NaN` speeds as `0` to avoid invalid recommendations.
 - `createCore` now accepts a custom registry for improved testability.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start -c",
     "dev": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
@@ -15,8 +15,7 @@
     "typecheck": "tsc --noEmit",
     "doctor": "expo doctor",
     "apk:debug": "npx expo run:android --variant debug",
-    "prepare": "husky install",
-    "clean": "rimraf node_modules .expo .turbo .cache && rimraf pnpm-lock.yaml"
+    "clean": "rimraf node_modules pnpm-lock.yaml .expo .cache .metro && pnpm store prune"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.24.0",
@@ -31,12 +30,10 @@
     "expo-location": "^18.0.0",
     "expo-speech": "^13.1.7",
     "i18n-js": "^4.5.1",
-    "metro": "^0.80.9",
     "react": "18.2.0",
     "react-native": "0.74.x",
     "react-native-maps": "1.14.0",
-    "react-native-svg": "15.2.0",
-    "tflite-react-native": "^0.0.5"
+    "react-native-svg": "15.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.3",
@@ -61,6 +58,7 @@
     "eslint-plugin-react-native": "^5.0.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
+    "metro": "0.80.12",
     "prettier": "^3.6.2",
     "react-test-renderer": "18.2.0",
     "rimraf": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ importers:
         version: 1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))
       '@react-native-firebase/analytics':
         specifier: ^23.1.2
-        version: 23.1.2(@react-native-firebase/app@23.1.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))
+        version: 23.2.0(@react-native-firebase/app@23.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))
       '@react-native-firebase/app':
         specifier: ^23.1.2
-        version: 23.1.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)
+        version: 23.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)
       '@supabase/supabase-js':
         specifier: ^2.56.0
-        version: 2.56.0
+        version: 2.56.1
       expo:
         specifier: ^53.0.0
         version: 53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)
@@ -44,9 +44,6 @@ importers:
       i18n-js:
         specifier: ^4.5.1
         version: 4.5.1
-      metro:
-        specifier: ^0.80.9
-        version: 0.80.12
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -59,9 +56,6 @@ importers:
       react-native-svg:
         specifier: 15.2.0
         version: 15.2.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)
-      tflite-react-native:
-        specifier: ^0.0.5
-        version: 0.0.5(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))
     devDependencies:
       '@babel/core':
         specifier: ^7.28.3
@@ -129,6 +123,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.11)
+      metro:
+        specifier: 0.80.12
+        version: 0.80.12
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -1635,13 +1632,13 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@react-native-firebase/analytics@23.1.2':
-    resolution: {integrity: sha512-fq/2GxRIwgXU6wxe55whI18K1GfQA9ZsnnI1FRUKNfhBV6m5g2CYasP9SgKv4kGj3WPh3JuaeebnKulCD0Xl9A==}
+  '@react-native-firebase/analytics@23.2.0':
+    resolution: {integrity: sha512-yNBaRc9oLAvRkOPPUsUDLl9dLEGJhS+YU8qhGbVb0aKJ8UpzR13DY9DL18TcAJH+35hwkmrvPE7glcEhrYDMbg==}
     peerDependencies:
-      '@react-native-firebase/app': 23.1.2
+      '@react-native-firebase/app': 23.2.0
 
-  '@react-native-firebase/app@23.1.2':
-    resolution: {integrity: sha512-GqnMjUvWZ7TzUvjbkuSa+5zOZVPz3jKOCp42tg3Fvxqu7fbw/M0P/SADHnTpoQaDvjf5FhJ7TGNhmB5+tjJ9yA==}
+  '@react-native-firebase/app@23.2.0':
+    resolution: {integrity: sha512-Ol9d0hnr1j2pPXYaWC+0UsQEcIiyVF7XufvyCifnMdnzfhPgrqnFwgqBCZm/jmWfosHIwhMexEuvaUuWtHDxrg==}
     peerDependencies:
       expo: '>=47.0.0'
       react: '*'
@@ -1853,8 +1850,8 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-  '@sinclair/typebox@0.34.40':
-    resolution: {integrity: sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==}
+  '@sinclair/typebox@0.34.41':
+    resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -1875,14 +1872,14 @@ packages:
   '@supabase/postgrest-js@1.21.3':
     resolution: {integrity: sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==}
 
-  '@supabase/realtime-js@2.15.1':
-    resolution: {integrity: sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==}
+  '@supabase/realtime-js@2.15.4':
+    resolution: {integrity: sha512-e/FYIWjvQJHOCNACWehnKvg26zosju3694k0NMUNb+JGLdvHJzEa29ZVVLmawd2kvx4hdbv8mxSqfttRnH3+DA==}
 
   '@supabase/storage-js@2.11.0':
     resolution: {integrity: sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==}
 
-  '@supabase/supabase-js@2.56.0':
-    resolution: {integrity: sha512-XqwhHSyVnkjdliPN61CmXsmFGnFHTX2WDdwjG3Ukvdzuu3Trix+dXupYOQ3BueIyYp7B6t0yYpdQtJP2hIInyg==}
+  '@supabase/supabase-js@2.56.1':
+    resolution: {integrity: sha512-cb/kS0d6G/qbcmUFItkqVrQbxQHWXzfRZuoiSDv/QiU6RbGNTn73XjjvmbBCZ4MMHs+5teihjhpEVluqbXISEg==}
 
   '@testing-library/react-hooks@8.0.1':
     resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
@@ -2333,11 +2330,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.25.3:
-    resolution: {integrity: sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   browserslist@4.25.4:
     resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2583,8 +2575,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  dayjs@1.11.15:
-    resolution: {integrity: sha512-MC+DfnSWiM9APs7fpiurHGCoeIx0Gdl6QZBy+5lu8MbYKN5FZEXqOgrundfibdfhGZ15o9hzmZ2xJjZnbvgKXQ==}
+  dayjs@1.11.18:
+    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -5037,11 +5029,6 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
-  tflite-react-native@0.0.5:
-    resolution: {integrity: sha512-aBajq5yQQ8UiB92tIk+v9BIKZTFGwCTHegfefISgnXwqPiPAAvKhdX6Vb80kJFPTUjXB53w/NZQT9qCyVBYMyA==}
-    peerDependencies:
-      react-native: ^0.41.2
-
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -7337,7 +7324,7 @@ snapshots:
 
   '@jest/schemas@30.0.5':
     dependencies:
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.41
 
   '@jest/source-map@29.6.3':
     dependencies:
@@ -7607,12 +7594,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native-firebase/analytics@23.1.2(@react-native-firebase/app@23.1.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))':
+  '@react-native-firebase/analytics@23.2.0(@react-native-firebase/app@23.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@react-native-firebase/app': 23.1.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)
+      '@react-native-firebase/app': 23.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)
       superstruct: 2.0.2
 
-  '@react-native-firebase/app@23.1.2(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)':
+  '@react-native-firebase/app@23.2.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))(expo@53.0.20(@babel/core@7.28.3)(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0))(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0))(react@18.2.0)':
     dependencies:
       firebase: 12.1.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)))
       react: 18.2.0
@@ -7934,7 +7921,7 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sinclair/typebox@0.34.40': {}
+  '@sinclair/typebox@0.34.41': {}
 
   '@sinonjs/commons@3.0.1':
     dependencies:
@@ -7960,7 +7947,7 @@ snapshots:
     dependencies:
       '@supabase/node-fetch': 2.6.15
 
-  '@supabase/realtime-js@2.15.1':
+  '@supabase/realtime-js@2.15.4':
     dependencies:
       '@supabase/node-fetch': 2.6.15
       '@types/phoenix': 1.6.6
@@ -7974,13 +7961,13 @@ snapshots:
     dependencies:
       '@supabase/node-fetch': 2.6.15
 
-  '@supabase/supabase-js@2.56.0':
+  '@supabase/supabase-js@2.56.1':
     dependencies:
       '@supabase/auth-js': 2.71.1
       '@supabase/functions-js': 2.4.5
       '@supabase/node-fetch': 2.6.15
       '@supabase/postgrest-js': 1.21.3
-      '@supabase/realtime-js': 2.15.1
+      '@supabase/realtime-js': 2.15.4
       '@supabase/storage-js': 2.11.0
     transitivePeerDependencies:
       - bufferutil
@@ -8576,13 +8563,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.25.3:
-    dependencies:
-      caniuse-lite: 1.0.30001737
-      electron-to-chromium: 1.5.211
-      node-releases: 2.0.19
-      update-browserslist-db: 1.1.3(browserslist@4.25.3)
-
   browserslist@4.25.4:
     dependencies:
       caniuse-lite: 1.0.30001737
@@ -8786,7 +8766,7 @@ snapshots:
 
   core-js-compat@3.45.1:
     dependencies:
-      browserslist: 4.25.3
+      browserslist: 4.25.4
 
   core-util-is@1.0.3: {}
 
@@ -8855,7 +8835,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  dayjs@1.11.15: {}
+  dayjs@1.11.18: {}
 
   debug@2.6.9:
     dependencies:
@@ -10484,7 +10464,7 @@ snapshots:
   logkitty@0.7.1:
     dependencies:
       ansi-fragments: 0.2.1
-      dayjs: 1.11.15
+      dayjs: 1.11.18
       yargs: 15.4.1
 
   long@5.3.2: {}
@@ -11835,10 +11815,6 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  tflite-react-native@0.0.5(react-native@0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)):
-    dependencies:
-      react-native: 0.74.7(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@18.3.24)(react@18.2.0)
-
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -11997,12 +11973,6 @@ snapshots:
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
-
-  update-browserslist-db@1.1.3(browserslist@4.25.3):
-    dependencies:
-      browserslist: 4.25.3
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.1.3(browserslist@4.25.4):
     dependencies:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,4 +28,10 @@ describe('createCore', () => {
     expect(core.createNavigation).toBe(navigation.createNavigation);
     expect(core.initialState).toBe(navigation.initialState);
   });
+
+  it('allows injecting custom cloneNavigationState', () => {
+    const clone = jest.fn();
+    const core = createCore({ cloneNavigationState: clone });
+    expect(core.cloneNavigationState).toBe(clone);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { cloneNavigationState } from './features/navigation/cloneNavigationState';
+import { cloneNavigationState as defaultCloneNavigationState } from './features/navigation/cloneNavigationState';
 import * as navigationFactory from './navigationFactory';
 import * as registry from './registryManager';
 
@@ -8,11 +8,13 @@ interface CoreDeps {
     initialState: typeof navigationFactory.initialState;
   };
   registry?: typeof registry;
+  cloneNavigationState?: typeof defaultCloneNavigationState;
 }
 
 export function createCore({
   navigation = navigationFactory,
   registry: registryDep = registry,
+  cloneNavigationState = defaultCloneNavigationState,
 }: CoreDeps = {}) {
   return {
     cloneNavigationState,
@@ -23,7 +25,7 @@ export function createCore({
 }
 
 export const { createNavigation, initialState } = navigationFactory;
-export { cloneNavigationState };
+export const cloneNavigationState = defaultCloneNavigationState;
 
 export const {
   createRegistryManager,


### PR DESCRIPTION
## Summary
- configure pnpm with hoisted node linker for Expo 53 and remove tflite
- expose `cloneNavigationState` as injectable dependency in core
- document pnpm setup in README

## Testing
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b2929e9da88323addb511d0eaba9f3