### PR TITLE
fix(notifications): respect lead-time when scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - refactor: rename maneuver panel style
 - feat: schedule notifications for upcoming green phases
 - feat: allow lead-time offset for green-phase notifications
+- fix: respect lead-time when scheduling green-phase notifications
 - fix: guard NaN speeds in navigation advisor
 
 ## 2025-09

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Open a pull request on GitHub and request a review.
 - Added notifications for upcoming green phases.
 - Added lead-time setting for green-phase notifications.
 - Persisted lead-time preference across sessions.
+- Fixed green-phase notifications to trigger immediately when lead time has elapsed.
 - `subscribeToPhaseChanges` now returns an unsubscribe callback to remove listeners.
 - Extracted registry manager into dedicated module for improved testability.
 - Added registry manager factory for isolated module registries in tests.

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -65,6 +65,18 @@ describe('notifications service', () => {
     });
   });
 
+  it('triggers immediately when lead time exceeds start time', async () => {
+    (getUpcomingPhase as jest.Mock).mockResolvedValueOnce({
+      direction: 'MAIN',
+      startIn: 3,
+    });
+    await notifyGreenPhase('3', 5);
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: { title: 'Upcoming green', body: 'MAIN in 0s' },
+      trigger: null,
+    });
+  });
+
   it('does not schedule when no upcoming phase', async () => {
     (getUpcomingPhase as jest.Mock).mockResolvedValueOnce(null);
     await notifyGreenPhase('1');

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -38,7 +38,7 @@ export async function notifyGreenPhase(
       title: 'Upcoming green',
       body: `${upcoming.direction} in ${Math.round(startIn)}s`,
     },
-    trigger: upcoming.startIn > 0 ? { seconds: Math.ceil(startIn) } : null,
+    trigger: startIn > 0 ? { seconds: Math.ceil(startIn) } : null,
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure green-phase notifications use lead-time offset when setting trigger
- test immediate trigger when lead time exceeds start time
- document fix in changelog and README

## Testing
- `pre-commit run --files src/services/notifications.ts src/services/__tests__/notifications.test.ts`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b242057c6483239f13a985139def69