### PR TITLE
test: notifyGreenPhase uses null trigger when lead time exceeded

### DIFF
--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -65,16 +65,15 @@ describe('notifications service', () => {
     });
   });
 
-  it('triggers immediately when lead time exceeds start', async () => {
+  it('uses null trigger when lead time exceeds start', async () => {
     (getUpcomingPhase as jest.Mock).mockResolvedValueOnce({
       direction: 'MAIN',
       startIn: 3,
     });
-    await notifyGreenPhase('3', 5);
-    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
-      content: { title: 'Upcoming green', body: 'MAIN in 0s' },
-      trigger: null,
-    });
+    await notifyGreenPhase('id', 5);
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: null }),
+    );
   });
 
   it('does not schedule when no upcoming phase', async () => {


### PR DESCRIPTION
## Summary
- simplify null-trigger assertion for notifyGreenPhase when lead time surpasses upcoming phase start

## Testing
- `pre-commit run --files src/services/__tests__/notifications.test.ts`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b2b7a44e988323a4086eaeb3711b91