### PR TITLE
docs: clarify debugging guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ supabase db push    # apply migrations to the remote project
 Write debug messages to `data/app.log` with the logger:
 
 ```ts
-import { log } from './src/services/logger';
+import { log } from 'src/services/logger';
 
 await log('INFO', 'App started');
 ```
 
-Each line follows `YYYY-MM-DD HH:MM:SS [LEVEL] message`.
+Each line follows `YYYY-MM-DD HH:MM:SS [LEVEL] message`. View the file with `tail -f data/app.log` or via the in-app log viewer.
 
 ### Voice phase logger
 


### PR DESCRIPTION
## Summary
- update README debug snippet to use absolute logger import
- document how to view `data/app.log`

## Testing
- `pre-commit run --files README.md`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b2b8d0a29c83238d09aaf2c3bc4468