### PR TITLE
refactor: import cloneNavigationState directly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { cloneNavigationState as defaultCloneNavigationState } from './features/navigation/cloneNavigationState';
+import { cloneNavigationState } from './features/navigation/cloneNavigationState';
 import * as navigationFactory from './navigationFactory';
 import * as registry from './registryManager';
 
@@ -8,16 +8,16 @@ interface CoreDeps {
     initialState: typeof navigationFactory.initialState;
   };
   registry?: typeof registry;
-  cloneNavigationState?: typeof defaultCloneNavigationState;
+  cloneNavigationState?: typeof cloneNavigationState;
 }
 
 export function createCore({
   navigation = navigationFactory,
   registry: registryDep = registry,
-  cloneNavigationState = defaultCloneNavigationState,
+  cloneNavigationState: clone = cloneNavigationState,
 }: CoreDeps = {}) {
   return {
-    cloneNavigationState,
+    cloneNavigationState: clone,
     createNavigation: navigation.createNavigation,
     initialState: navigation.initialState,
     ...registryDep,
@@ -25,7 +25,7 @@ export function createCore({
 }
 
 export const { createNavigation, initialState } = navigationFactory;
-export const cloneNavigationState = defaultCloneNavigationState;
+export { cloneNavigationState };
 
 export const {
   createRegistryManager,

--- a/src/navigationFactory.ts
+++ b/src/navigationFactory.ts
@@ -6,7 +6,7 @@ import {
   computeRecommendation,
 } from './features/navigation';
 import type { NavigationState, LightOnRoute } from './features/navigation';
-import { cloneNavigationState } from './index';
+import { cloneNavigationState } from './features/navigation/cloneNavigationState';
 
 export interface NavigationDeps {
   handleStartNavigation: typeof handleStartNavigation;


### PR DESCRIPTION
## Summary
- import `cloneNavigationState` directly from navigation feature
- re-export `cloneNavigationState` from the root index

## Testing
- `pre-commit run --files src/index.ts src/navigationFactory.ts`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b314ec37dc83239773333a7059e155