### PR TITLE
refactor: extract core creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ New contributors can start by exploring the folders below to see how the app is 
 - Start with [`README.md`](README.md) and [`CHANGELOG.md`](CHANGELOG.md) to see recent changes.
 - Navigation helpers live in `src/features/navigation` and are re-exported from `src/index.ts`.
 - Use `createNavigation()` from `src/index.ts` to obtain test-friendly navigation helpers.
-- `createCore({ navigation, registry })` in `src/index.ts` lets you inject test doubles for navigation or registry logic.
+ - `createCore({ navigation, registry })` in `src/core.ts` lets you inject test doubles for navigation or registry logic and is re-exported from `src/index.ts`.
 - Tests sit next to code; see `src/features/navigation/__tests__` for examples.
 
 Service interfaces are named `SupabaseService`, `AnalyticsService`, etc., and live in `src/interfaces/`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Open a pull request on GitHub and request a review.
 ## Recent changes
 
 - Configured pnpm with hoisted node linker for Expo 53 compatibility and removed `tflite-react-native`.
+- Centralized core creation in `src/core.ts` and simplified exports.
 - Driving HUD reacts to speech-setting toggles.
 - Navigation advisor treats `NaN` speeds as `0` to avoid invalid recommendations.
 - `createCore` now accepts a custom registry for improved testability.

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -1,0 +1,38 @@
+import { createCore } from './core';
+import { createNavigation } from './navigationFactory';
+
+describe('createCore', () => {
+  it('exposes navigation helpers and registry functions', () => {
+    const core = createCore();
+    expect(core.createNavigation).toBe(createNavigation);
+    expect(typeof core.createRegistryManager).toBe('function');
+    expect(typeof core.getRegistry).toBe('function');
+  });
+
+  it('allows injecting custom registry', () => {
+    const custom = {
+      createRegistryManager: jest.fn(),
+    } as unknown as typeof import('./registryManager');
+    const core = createCore({ registry: custom });
+    expect(core.createRegistryManager).toBe(custom.createRegistryManager);
+  });
+
+  it('allows injecting custom navigation', () => {
+    const navigation = {
+      createNavigation: jest.fn(),
+      initialState: { foo: 'bar' },
+    } as unknown as {
+      createNavigation: typeof createNavigation;
+      initialState: typeof import('./navigationFactory').initialState;
+    };
+    const core = createCore({ navigation });
+    expect(core.createNavigation).toBe(navigation.createNavigation);
+    expect(core.initialState).toBe(navigation.initialState);
+  });
+
+  it('allows injecting custom cloneNavigationState', () => {
+    const clone = jest.fn();
+    const core = createCore({ cloneNavigationState: clone });
+    expect(core.cloneNavigationState).toBe(clone);
+  });
+});

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,27 @@
+import { cloneNavigationState } from './features/navigation/cloneNavigationState';
+import * as navigationFactory from './navigationFactory';
+import * as registry from './registryManager';
+
+export interface CoreDeps {
+  navigation?: {
+    createNavigation: typeof navigationFactory.createNavigation;
+    initialState: typeof navigationFactory.initialState;
+  };
+  registry?: typeof registry;
+  cloneNavigationState?: typeof cloneNavigationState;
+}
+
+export function createCore({
+  navigation = navigationFactory,
+  registry: registryDep = registry,
+  cloneNavigationState: clone = cloneNavigationState,
+}: CoreDeps = {}) {
+  return {
+    cloneNavigationState: clone,
+    createNavigation: navigation.createNavigation,
+    initialState: navigation.initialState,
+    ...registryDep,
+  };
+}
+
+export type Core = ReturnType<typeof createCore>;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,37 +1,8 @@
-import { createCore, createNavigation } from './index';
+import { createCore } from './index';
+import * as core from './core';
 
-describe('createCore', () => {
-  it('exposes navigation helpers and registry functions', () => {
-    const core = createCore();
-    expect(core.createNavigation).toBe(createNavigation);
-    expect(typeof core.createRegistryManager).toBe('function');
-    expect(typeof core.getRegistry).toBe('function');
-  });
-
-  it('allows injecting custom registry', () => {
-    const custom = {
-      createRegistryManager: jest.fn(),
-    } as unknown as typeof import('./registryManager');
-    const core = createCore({ registry: custom });
-    expect(core.createRegistryManager).toBe(custom.createRegistryManager);
-  });
-
-  it('allows injecting custom navigation', () => {
-    const navigation = {
-      createNavigation: jest.fn(),
-      initialState: { foo: 'bar' },
-    } as unknown as {
-      createNavigation: typeof createNavigation;
-      initialState: typeof import('./navigationFactory').initialState;
-    };
-    const core = createCore({ navigation });
-    expect(core.createNavigation).toBe(navigation.createNavigation);
-    expect(core.initialState).toBe(navigation.initialState);
-  });
-
-  it('allows injecting custom cloneNavigationState', () => {
-    const clone = jest.fn();
-    const core = createCore({ cloneNavigationState: clone });
-    expect(core.cloneNavigationState).toBe(clone);
+describe('index exports', () => {
+  it('re-exports createCore', () => {
+    expect(createCore).toBe(core.createCore);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,9 @@
-import { cloneNavigationState } from './features/navigation/cloneNavigationState';
-import * as navigationFactory from './navigationFactory';
-import * as registry from './registryManager';
+export { createCore } from './core';
+export type { Core, CoreDeps } from './core';
 
-interface CoreDeps {
-  navigation?: {
-    createNavigation: typeof navigationFactory.createNavigation;
-    initialState: typeof navigationFactory.initialState;
-  };
-  registry?: typeof registry;
-  cloneNavigationState?: typeof cloneNavigationState;
-}
-
-export function createCore({
-  navigation = navigationFactory,
-  registry: registryDep = registry,
-  cloneNavigationState: clone = cloneNavigationState,
-}: CoreDeps = {}) {
-  return {
-    cloneNavigationState: clone,
-    createNavigation: navigation.createNavigation,
-    initialState: navigation.initialState,
-    ...registryDep,
-  };
-}
-
-export const { createNavigation, initialState } = navigationFactory;
-export { cloneNavigationState };
-
-export const {
+export { createNavigation, initialState } from './navigationFactory';
+export { cloneNavigationState } from './features/navigation/cloneNavigationState';
+export {
   createRegistryManager,
   setRegistry,
   initRegistry,
@@ -37,4 +13,4 @@ export const {
   getProcessors,
   getSources,
   getStores,
-} = registry;
+} from './registryManager';


### PR DESCRIPTION
## Summary
- move createCore and dependencies to src/core.ts
- simplify index exports and re-export createCore
- add core dependency injection tests

## Testing
- `pre-commit run --files AGENTS.md README.md src/index.ts src/core.ts src/core.test.ts src/index.test.ts`
- `pnpm lint --format unix`
- `pnpm test --coverage`
- `pnpm audit`


------
https://chatgpt.com/codex/tasks/task_e_68b316a9c5e4832385dbcc9e4053fb3c