### PR TITLE
feat: split GPT client into prompt and parse helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Open a pull request on GitHub and request a review.
 
 ## Recent changes
 
+- Renamed GPT API client to `client.ts` and split prompt formatting and response parsing into `prompt.ts` and `parse.ts`.
 - Configured pnpm with hoisted node linker for Expo 53 compatibility and removed `tflite-react-native`.
 - Centralized core creation in `src/core.ts` and simplified exports.
 - Driving HUD reacts to speech-setting toggles.

--- a/src/services/gpt/AGENTS.md
+++ b/src/services/gpt/AGENTS.md
@@ -2,8 +2,9 @@
 
 Guidelines for GPT service modules.
 
-- Keep API calls isolated in `apiClient.ts` with injectable `fetch` for testing.
+- Keep API calls isolated in `client.ts` with injectable `fetch` for testing.
 - Pure helpers belong in `utils.ts` and should remain stateless.
-- `promptHandler.ts` formats prompts without side effects.
+- `prompt.ts` formats prompts without side effects.
+- `parse.ts` extracts content from API responses.
 - Place tests in `__tests__/` alongside the modules.
 - Run `pre-commit run --files <files>` and `pnpm test -- --coverage` after changes.

--- a/src/services/gpt/__tests__/client.test.ts
+++ b/src/services/gpt/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { createGptClient } from '../apiClient';
+import { createGptClient } from '../client';
 import * as logger from '../../logger';
 
 describe('createGptClient', () => {

--- a/src/services/gpt/__tests__/parse.test.ts
+++ b/src/services/gpt/__tests__/parse.test.ts
@@ -1,0 +1,15 @@
+import { extractContent } from '../parse';
+
+describe('extractContent', () => {
+  it('returns first message content', () => {
+    const result = extractContent({
+      choices: [{ message: { content: 'hi' } }],
+    });
+    expect(result).toBe('hi');
+  });
+
+  it('returns empty string when missing', () => {
+    const result = extractContent({ choices: [] });
+    expect(result).toBe('');
+  });
+});

--- a/src/services/gpt/__tests__/prompt.test.ts
+++ b/src/services/gpt/__tests__/prompt.test.ts
@@ -1,0 +1,8 @@
+import { formatPrompt } from '../prompt';
+
+describe('formatPrompt', () => {
+  it('replaces variables in template', () => {
+    const result = formatPrompt('Hello {name}', { name: 'Alice' });
+    expect(result).toBe('Hello Alice');
+  });
+});

--- a/src/services/gpt/__tests__/promptHandler.test.ts
+++ b/src/services/gpt/__tests__/promptHandler.test.ts
@@ -1,8 +1,0 @@
-import { buildPrompt } from '../promptHandler';
-
-describe('buildPrompt', () => {
-  it('replaces variables in template', () => {
-    const result = buildPrompt('Hello {name}', { name: 'Alice' });
-    expect(result).toBe('Hello Alice');
-  });
-});

--- a/src/services/gpt/client.ts
+++ b/src/services/gpt/client.ts
@@ -1,4 +1,5 @@
 import { log } from '../logger';
+import { extractContent, GptResponse } from './parse';
 
 export interface GptClient {
   complete(prompt: string): Promise<string>;
@@ -28,17 +29,15 @@ export function createGptClient(
         throw new Error(await res.text());
       }
 
-      let data: { choices: { message: { content: string } }[] };
+      let data: GptResponse;
       try {
-        data = (await res.json()) as {
-          choices: { message: { content: string } }[];
-        };
+        data = (await res.json()) as GptResponse;
       } catch (error) {
         await log('ERROR', `Failed to parse GPT response: ${String(error)}`);
         throw error;
       }
 
-      return data.choices[0]?.message.content ?? '';
+      return extractContent(data);
     },
   };
 }

--- a/src/services/gpt/index.ts
+++ b/src/services/gpt/index.ts
@@ -1,3 +1,4 @@
-export * from './apiClient';
-export * from './promptHandler';
+export * from './client';
+export * from './prompt';
+export * from './parse';
 export * from './utils';

--- a/src/services/gpt/parse.ts
+++ b/src/services/gpt/parse.ts
@@ -1,0 +1,7 @@
+export interface GptResponse {
+  choices: { message: { content: string } }[];
+}
+
+export function extractContent(data: GptResponse): string {
+  return data.choices[0]?.message.content ?? '';
+}

--- a/src/services/gpt/prompt.ts
+++ b/src/services/gpt/prompt.ts
@@ -1,4 +1,4 @@
-export function buildPrompt(
+export function formatPrompt(
   template: string,
   vars: Record<string, string>,
 ): string {


### PR DESCRIPTION
## Summary
- rename GPT API client to `client.ts`
- add `prompt.ts` to format templates and `parse.ts` to extract completion text
- update tests and docs

## Testing
- `pre-commit run --files README.md src/services/gpt/AGENTS.md src/services/gpt/client.ts src/services/gpt/prompt.ts src/services/gpt/parse.ts src/services/gpt/index.ts src/services/gpt/__tests__/client.test.ts src/services/gpt/__tests__/prompt.test.ts src/services/gpt/__tests__/parse.test.ts`
- `pnpm lint --format unix`
- `pnpm test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b318b6e1f0832386bab5096f68546e