### PR TITLE
Validate ORS response shape and surface clear error

### DIFF
--- a/src/services/__tests__/ors.test.ts
+++ b/src/services/__tests__/ors.test.ts
@@ -90,4 +90,18 @@ describe('getRoute', () => {
     });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('throws on invalid response shape', async () => {
+    const json = {
+      features: [],
+    };
+    const fetchSpy = jest
+      .spyOn(network, 'fetchWithTimeout')
+      .mockResolvedValue({ json: async () => json } as unknown as Response);
+
+    await expect(getRoute(start, end)).rejects.toThrow(
+      'Invalid ORS response shape',
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/services/navigation/ors.ts
+++ b/src/services/navigation/ors.ts
@@ -20,6 +20,67 @@ export interface RouteResult {
   steps: RouteStep[];
 }
 
+type ORSFeature = {
+  geometry: {
+    coordinates: [number, number][];
+  };
+  properties: {
+    summary: {
+      distance: number;
+      duration: number;
+    };
+    segments?: Array<{
+      steps?: unknown[];
+    }>;
+  };
+};
+
+const isNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const hasValidCoordinates = (
+  coords: unknown,
+): coords is [number, number][] =>
+  Array.isArray(coords) &&
+  coords.every(
+    (pair) =>
+      Array.isArray(pair) &&
+      pair.length >= 2 &&
+      isNumber(pair[0]) &&
+      isNumber(pair[1]),
+  );
+
+const hasValidSummary = (
+  summary: unknown,
+): summary is ORSFeature['properties']['summary'] =>
+  !!summary &&
+  typeof summary === 'object' &&
+  isNumber((summary as { distance?: unknown }).distance) &&
+  isNumber((summary as { duration?: unknown }).duration);
+
+const isValidOrsResponse = (data: unknown): data is { features: ORSFeature[] } => {
+  if (!data || typeof data !== 'object') {
+    return false;
+  }
+  const features = (data as { features?: unknown }).features;
+  if (!Array.isArray(features) || features.length === 0) {
+    return false;
+  }
+  const feature = features[0] as ORSFeature | undefined;
+  if (!feature || typeof feature !== 'object') {
+    return false;
+  }
+  const geometry = feature.geometry;
+  const properties = feature.properties;
+  if (!geometry || !properties) {
+    return false;
+  }
+  return (
+    hasValidCoordinates(geometry.coordinates) &&
+    hasValidSummary(properties.summary)
+  );
+};
+
 export async function getRoute(
   start: LatLng,
   end: LatLng,
@@ -42,10 +103,10 @@ export async function getRoute(
   }
 
   const json = await res.json();
-  const feature = json.features?.[0];
-  if (!feature) {
-    throw new Error('Route not found');
+  if (!isValidOrsResponse(json)) {
+    throw new Error('Invalid ORS response shape');
   }
+  const feature = json.features[0];
   const coords: LatLng[] = feature.geometry.coordinates.map(
     ([lon, lat]: [number, number]) => ({
       latitude: lat,


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes when parsing OpenRouteService payloads by asserting the minimal expected shape before accessing nested properties.
- Provide a clear, actionable error (`Invalid ORS response shape`) when the response is malformed instead of failing with unclear runtime exceptions.

### Description
- Add a compact runtime type guard (`isValidOrsResponse`) and helper predicates (`hasValidCoordinates`, `hasValidSummary`) to `src/services/navigation/ors.ts` to validate `features[0].geometry.coordinates` and `properties.summary` before parsing.
- Replace the previous loose `json.features?.[0]` check with the guard and throw `Invalid ORS response shape` when validation fails.
- Introduce an `ORSFeature` type to codify the minimal expected shape and keep the runtime checks aligned with TypeScript types.
- Add a negative Jest test `it('throws on invalid response shape')` in `src/services/__tests__/ors.test.ts` that mocks an empty `features` array and asserts the new error is thrown.

### Testing
- A unit test was added at `src/services/__tests__/ors.test.ts` covering the invalid-response negative case and expects `Invalid ORS response shape` to be thrown.
- Existing positive and error path tests in the same file remain and exercise parsing and fetch error handling via `network.fetchWithTimeout` mocks.
- No test suite was executed as part of this change (tests were added but not run in this rollout).
- Pre-commit/test hooks should be run locally with `pnpm test -- --coverage` and `pnpm lint` before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b34ff1f083239d5567f71fb5d09e)