### PR TITLE
feat: add Node backend for Telegram WebApp auth and ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 React Native (Expo) app with real-time traffic-light detection, premium subscriptions, and analytics.
 
 See [docs/API.md](docs/API.md) for available REST endpoints.
+For the Node.js backend that handles Telegram WebApp auth and ordering settings, see
+[docs/telegram-node-backend.md](docs/telegram-node-backend.md).
 
 ## Branches
 

--- a/docs/telegram-node-backend.md
+++ b/docs/telegram-node-backend.md
@@ -1,0 +1,79 @@
+# Telegram WebApp auth + orders (Node.js backend)
+
+## Минимальные требования
+
+- Node.js >= 20.11
+- Supabase Postgres (service role ключ)
+- Telegram Bot Token
+
+## Запуск
+
+```bash
+cd server
+pnpm install
+cp .env.example .env
+pnpm dev
+```
+
+## Переменные окружения
+
+| Переменная | Назначение |
+| --- | --- |
+| `PORT` | Порт API |
+| `CORS_ORIGIN` | Разрешённый origin для web |
+| `SUPABASE_URL` | URL Supabase проекта |
+| `SUPABASE_SERVICE_ROLE_KEY` | Service role key (нужен для записи) |
+| `TELEGRAM_BOT_TOKEN` | Bot Token для проверки initData |
+| `TELEGRAM_AUTH_MAX_AGE_SECONDS` | TTL initData (секунды) |
+| `AUTH_JWT_SECRET` | Секрет для JWT сессии |
+| `ADMIN_API_KEY` | Ключ администратора для обновления настроек |
+
+## API
+
+### POST /auth/telegram
+
+Тело:
+```json
+{ "initData": "<telegram-init-data>" }
+```
+
+Ответ:
+```json
+{ "token": "<jwt>", "profile": { "...": "..." } }
+```
+
+### GET /ordering-settings
+
+Ответ:
+```json
+{ "id": 1, "ordering_enabled": true, "preorder_enabled": true }
+```
+
+### PATCH /ordering-settings
+
+Заголовок:
+```
+x-admin-key: <ADMIN_API_KEY>
+```
+
+Тело:
+```json
+{ "ordering_enabled": false, "preorder_enabled": true }
+```
+
+### POST /orders
+
+Заголовок:
+```
+Authorization: Bearer <jwt>
+```
+
+Тело:
+```json
+{
+  "items": [{ "sku": "pizza-1", "title": "Маргарита", "quantity": 1, "price": 550 }],
+  "note": "Без лука"
+}
+```
+
+Если приём заказов выключен, но разрешён предзаказ — заказ создаётся как `order_type=preorder`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,8 @@
+PORT=3001
+CORS_ORIGIN=http://localhost:8081
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+TELEGRAM_BOT_TOKEN=123456:bot-token
+TELEGRAM_AUTH_MAX_AGE_SECONDS=86400
+AUTH_JWT_SECRET=replace-with-32-byte-secret
+ADMIN_API_KEY=replace-with-admin-key

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "greenwave-api",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "node --loader tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "engines": {
+    "node": ">=20.11.0"
+  },
+  "dependencies": {
+    "@fastify/cors": "^9.0.1",
+    "@supabase/supabase-js": "^2.56.1",
+    "fastify": "^4.28.1",
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.6",
+    "@types/node": "^20.19.11",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,27 @@
+import Fastify from 'fastify';
+import cors from '@fastify/cors';
+
+import { env } from './lib/env.js';
+import { registerAuthRoutes } from './routes/auth.js';
+import { registerSettingsRoutes } from './routes/settings.js';
+import { registerOrderRoutes } from './routes/orders.js';
+
+const server = Fastify({
+  logger: true
+});
+
+await server.register(cors, {
+  origin: env.CORS_ORIGIN,
+  credentials: true
+});
+
+await registerAuthRoutes(server);
+await registerSettingsRoutes(server);
+await registerOrderRoutes(server);
+
+try {
+  await server.listen({ port: Number(env.PORT), host: '0.0.0.0' });
+} catch (error) {
+  server.log.error(error);
+  process.exit(1);
+}

--- a/server/src/lib/env.ts
+++ b/server/src/lib/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  PORT: z.string().optional().default('3001'),
+  CORS_ORIGIN: z.string().optional().default('*'),
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  TELEGRAM_BOT_TOKEN: z.string().min(1),
+  TELEGRAM_AUTH_MAX_AGE_SECONDS: z.preprocess(
+    (value) => (value ? Number(value) : 86400),
+    z.number().int().positive()
+  ),
+  AUTH_JWT_SECRET: z.string().min(32),
+  ADMIN_API_KEY: z.string().min(16)
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+export const env = envSchema.parse(process.env);

--- a/server/src/lib/supabase.ts
+++ b/server/src/lib/supabase.ts
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+
+import { env } from './env.js';
+
+export const supabaseAdmin = createClient(
+  env.SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false
+    }
+  }
+);

--- a/server/src/lib/telegram.ts
+++ b/server/src/lib/telegram.ts
@@ -1,0 +1,76 @@
+import crypto from 'node:crypto';
+
+type TelegramUser = {
+  id: number;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+  photo_url?: string;
+};
+
+export type TelegramInitData = {
+  auth_date: number;
+  query_id?: string;
+  user?: TelegramUser;
+};
+
+const toHmac = (key: Buffer, data: string): string =>
+  crypto.createHmac('sha256', key).update(data).digest('hex');
+
+export const verifyInitData = (
+  initData: string,
+  botToken: string,
+  maxAgeSeconds: number
+): { ok: true; data: TelegramInitData } | { ok: false; error: string } => {
+  if (!initData) {
+    return { ok: false, error: 'Missing initData.' };
+  }
+
+  const params = new URLSearchParams(initData);
+  const hash = params.get('hash');
+  if (!hash) {
+    return { ok: false, error: 'Missing hash.' };
+  }
+  params.delete('hash');
+
+  const dataCheckString = [...params.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+
+  const secretKey = crypto.createHash('sha256').update(botToken).digest();
+  const computedHash = toHmac(secretKey, dataCheckString);
+
+  if (!crypto.timingSafeEqual(Buffer.from(computedHash), Buffer.from(hash))) {
+    return { ok: false, error: 'Invalid initData signature.' };
+  }
+
+  const authDate = Number(params.get('auth_date'));
+  if (!Number.isFinite(authDate)) {
+    return { ok: false, error: 'Invalid auth_date.' };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (nowSeconds - authDate > maxAgeSeconds) {
+    return { ok: false, error: 'initData expired.' };
+  }
+
+  const userRaw = params.get('user');
+  let user: TelegramUser | undefined;
+  if (userRaw) {
+    try {
+      user = JSON.parse(userRaw) as TelegramUser;
+    } catch (error) {
+      return { ok: false, error: 'Invalid user payload.' };
+    }
+  }
+
+  return {
+    ok: true,
+    data: {
+      auth_date: authDate,
+      query_id: params.get('query_id') ?? undefined,
+      user
+    }
+  };
+};

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,33 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import jwt from 'jsonwebtoken';
+
+import { env } from '../lib/env.js';
+
+export type AuthUser = {
+  userId: string;
+  telegramId: number;
+};
+
+export const requireAuth = async (
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<AuthUser | null> => {
+  const header = request.headers.authorization;
+  if (!header?.startsWith('Bearer ')) {
+    reply.status(401).send({ error: 'Missing bearer token.' });
+    return null;
+  }
+
+  const token = header.replace('Bearer ', '').trim();
+  try {
+    const payload = jwt.verify(token, env.AUTH_JWT_SECRET) as AuthUser;
+    if (!payload?.userId || !payload?.telegramId) {
+      reply.status(401).send({ error: 'Invalid token payload.' });
+      return null;
+    }
+    return payload;
+  } catch (error) {
+    reply.status(401).send({ error: 'Invalid or expired token.' });
+    return null;
+  }
+};

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,77 @@
+import type { FastifyInstance } from 'fastify';
+import jwt from 'jsonwebtoken';
+import { z } from 'zod';
+
+import { env } from '../lib/env.js';
+import { supabaseAdmin } from '../lib/supabase.js';
+import { verifyInitData } from '../lib/telegram.js';
+
+const telegramAuthSchema = z.object({
+  initData: z.string().min(1)
+});
+
+export const registerAuthRoutes = async (
+  fastify: FastifyInstance
+): Promise<void> => {
+  fastify.post('/auth/telegram', async (request, reply) => {
+    const parsed = telegramAuthSchema.safeParse(request.body);
+    if (!parsed.success) {
+      reply.status(400).send({ error: 'Invalid payload.' });
+      return;
+    }
+
+    const { initData } = parsed.data;
+    const verification = verifyInitData(
+      initData,
+      env.TELEGRAM_BOT_TOKEN,
+      env.TELEGRAM_AUTH_MAX_AGE_SECONDS
+    );
+
+    if (!verification.ok) {
+      reply.status(401).send({ error: verification.error });
+      return;
+    }
+
+    const telegramUser = verification.data.user;
+    if (!telegramUser?.id) {
+      reply.status(400).send({ error: 'Telegram user missing.' });
+      return;
+    }
+
+    const displayName = [
+      telegramUser.first_name,
+      telegramUser.last_name
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+
+    const { data: profile, error } = await supabaseAdmin
+      .from('user_profiles')
+      .upsert(
+        {
+          telegram_id: telegramUser.id,
+          username: telegramUser.username ?? null,
+          display_name: displayName || telegramUser.username || null,
+          avatar_url: telegramUser.photo_url ?? null,
+          last_login_at: new Date().toISOString()
+        },
+        { onConflict: 'telegram_id' }
+      )
+      .select()
+      .single();
+
+    if (error || !profile) {
+      reply.status(500).send({ error: 'Failed to persist profile.' });
+      return;
+    }
+
+    const token = jwt.sign(
+      { userId: profile.id, telegramId: telegramUser.id },
+      env.AUTH_JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+
+    reply.send({ token, profile });
+  });
+};

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -1,0 +1,83 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+import { requireAuth } from '../middleware/auth.js';
+import { supabaseAdmin } from '../lib/supabase.js';
+
+const orderPayloadSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        sku: z.string().min(1),
+        title: z.string().min(1),
+        quantity: z.number().int().positive(),
+        price: z.number().nonnegative()
+      })
+    )
+    .min(1),
+  note: z.string().max(500).optional()
+});
+
+const getSettings = async () => {
+  const { data, error } = await supabaseAdmin
+    .from('ordering_settings')
+    .select('*')
+    .single();
+  if (error || !data) {
+    throw error ?? new Error('Missing settings.');
+  }
+  return data;
+};
+
+export const registerOrderRoutes = async (
+  fastify: FastifyInstance
+): Promise<void> => {
+  fastify.post('/orders', async (request, reply) => {
+    const user = await requireAuth(request, reply);
+    if (!user) {
+      return;
+    }
+
+    const parsed = orderPayloadSchema.safeParse(request.body);
+    if (!parsed.success) {
+      reply.status(400).send({ error: 'Invalid payload.' });
+      return;
+    }
+
+    let settings;
+    try {
+      settings = await getSettings();
+    } catch (error) {
+      reply.status(500).send({ error: 'Failed to load settings.' });
+      return;
+    }
+
+    if (!settings.ordering_enabled && !settings.preorder_enabled) {
+      reply.status(409).send({
+        error: 'Ordering is disabled.',
+        preorder_available: false
+      });
+      return;
+    }
+
+    const orderType = settings.ordering_enabled ? 'regular' : 'preorder';
+
+    const { data: order, error } = await supabaseAdmin
+      .from('orders')
+      .insert({
+        user_profile_id: user.userId,
+        order_type: orderType,
+        status: 'pending',
+        payload: parsed.data
+      })
+      .select()
+      .single();
+
+    if (error || !order) {
+      reply.status(500).send({ error: 'Failed to create order.' });
+      return;
+    }
+
+    reply.send({ order, order_type: orderType });
+  });
+};

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+import { env } from '../lib/env.js';
+import { supabaseAdmin } from '../lib/supabase.js';
+
+const settingsSchema = z.object({
+  ordering_enabled: z.boolean(),
+  preorder_enabled: z.boolean()
+});
+
+const ensureSettings = async () => {
+  const { data, error } = await supabaseAdmin
+    .from('ordering_settings')
+    .select('*')
+    .single();
+
+  if (data) {
+    return data;
+  }
+
+  if (error && error.code !== 'PGRST116') {
+    throw error;
+  }
+
+  const { data: inserted, error: insertError } = await supabaseAdmin
+    .from('ordering_settings')
+    .insert({ ordering_enabled: true, preorder_enabled: true })
+    .select()
+    .single();
+
+  if (insertError || !inserted) {
+    throw insertError ?? new Error('Failed to create settings.');
+  }
+
+  return inserted;
+};
+
+export const registerSettingsRoutes = async (
+  fastify: FastifyInstance
+): Promise<void> => {
+  fastify.get('/ordering-settings', async (_, reply) => {
+    try {
+      const settings = await ensureSettings();
+      reply.send(settings);
+    } catch (error) {
+      reply.status(500).send({ error: 'Failed to load settings.' });
+    }
+  });
+
+  fastify.patch('/ordering-settings', async (request, reply) => {
+    const adminKey = request.headers['x-admin-key'];
+    if (adminKey !== env.ADMIN_API_KEY) {
+      reply.status(403).send({ error: 'Forbidden.' });
+      return;
+    }
+
+    const parsed = settingsSchema.safeParse(request.body);
+    if (!parsed.success) {
+      reply.status(400).send({ error: 'Invalid payload.' });
+      return;
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('ordering_settings')
+      .update({ ...parsed.data, updated_at: new Date().toISOString() })
+      .eq('id', 1)
+      .select()
+      .single();
+
+    if (error || !data) {
+      reply.status(500).send({ error: 'Failed to update settings.' });
+      return;
+    }
+
+    reply.send(data);
+  });
+};

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/supabase/migrations/20250115_auth_orders.sql
+++ b/supabase/migrations/20250115_auth_orders.sql
@@ -1,0 +1,57 @@
+-- User profiles for Telegram auth
+create table if not exists public.user_profiles (
+  id uuid primary key default gen_random_uuid(),
+  telegram_id bigint unique not null,
+  username text,
+  display_name text,
+  avatar_url text,
+  phone text,
+  last_login_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+-- Ordering settings (single row)
+create table if not exists public.ordering_settings (
+  id int primary key default 1,
+  ordering_enabled boolean not null default true,
+  preorder_enabled boolean not null default true,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.ordering_settings (id, ordering_enabled, preorder_enabled)
+values (1, true, true)
+on conflict (id) do nothing;
+
+-- Orders
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  user_profile_id uuid not null references public.user_profiles(id) on delete cascade,
+  order_type text not null check (order_type in ('regular', 'preorder')),
+  status text not null check (status in ('pending', 'accepted', 'rejected', 'completed')),
+  payload jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists orders_user_profile_id_idx on public.orders(user_profile_id);
+
+-- RLS
+alter table public.user_profiles enable row level security;
+alter table public.ordering_settings enable row level security;
+alter table public.orders enable row level security;
+
+-- Public read of ordering settings
+create policy "Public read ordering settings" on public.ordering_settings
+  for select using (true);
+
+-- Authenticated read/write for profiles and orders (for future Supabase auth usage)
+create policy "Auth read profiles" on public.user_profiles
+  for select using (auth.role() = 'authenticated');
+create policy "Auth write profiles" on public.user_profiles
+  for all using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy "Auth read orders" on public.orders
+  for select using (auth.role() = 'authenticated');
+create policy "Auth write orders" on public.orders
+  for all using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');


### PR DESCRIPTION
### Motivation

- Provide a small standalone Node.js API to verify Telegram WebApp `initData`, issue JWTs and persist Telegram user profiles in Supabase for client sessions.
- Centralize ordering configuration and order ingestion in the backend so an admin can toggle accepting orders or allow preorders and the mobile/web client can consume a single authoritative API.

### Description

- Added a TypeScript Fastify server under `server/` with `package.json`, `tsconfig.json`, env validation (`server/src/lib/env.ts`) and a runnable `server/src/index.ts` entrypoint.
- Implemented Telegram WebApp `initData` verification in `server/src/lib/telegram.ts` and an `/auth/telegram` route that upserts `user_profiles` in Supabase and returns a JWT session (`server/src/routes/auth.ts`).
- Added admin-controlled settings and order endpoints: `GET /ordering-settings` and `PATCH /ordering-settings` guarded by `x-admin-key`, and `POST /orders` protected by JWT which creates orders as `regular` or `preorder` depending on settings (`server/src/routes/settings.ts`, `server/src/routes/orders.ts`, `server/src/middleware/auth.ts`).
- Introduced a Supabase migration `supabase/migrations/20250115_auth_orders.sql` that creates `user_profiles`, `ordering_settings`, and `orders` tables with indexes and RLS policies, and added documentation `docs/telegram-node-backend.md` plus README link.

### Testing

- No automated tests were executed for these changes (no CI/test run was performed as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967dccbf7188323be8209f722b7a49d)